### PR TITLE
Visual overhaul: 8 themes, theme-reactive UI, and elevated typing surfaces

### DIFF
--- a/src/components/AboutOverlay.tsx
+++ b/src/components/AboutOverlay.tsx
@@ -25,7 +25,7 @@ const AboutOverlay = React.memo((props: AboutOverlayProps) => {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-base/82 backdrop-blur-lg" role="dialog" aria-modal="true">
+    <div className="overlay-backdrop fixed inset-0 z-[60] flex items-center justify-center bg-base/82 backdrop-blur-lg" role="dialog" aria-modal="true">
       {/* background click to close */}
       <Button
         type="button"
@@ -40,7 +40,7 @@ const AboutOverlay = React.memo((props: AboutOverlayProps) => {
         <span className="sr-only">Dismiss overlay</span>
       </Button>
 
-      <div className="relative z-10 w-full max-w-2xl mx-4 overflow-hidden rounded-3xl border border-muted/20 bg-surface/70 backdrop-blur-xl shadow-[0_28px_80px_RGBA(10,4,22,0.45)]">
+      <div className="overlay-card relative z-10 w-full max-w-2xl mx-4 overflow-hidden rounded-3xl border border-muted/20 bg-surface/70 backdrop-blur-xl shadow-[0_28px_80px_RGBA(10,4,22,0.45)]">
         <div className="relative px-8 pt-8 pb-6 bg-gradient-to-br from-[color-mix(in_oklab,var(--rp-iris)80%,#0b0614_20%)]/38 via-transparent to-transparent">
           <h2 className="text-[clamp(1.6rem,2vw,2.1rem)] font-semibold tracking-tight text-foam drop-shadow-[0_1px_8px_RGBA(196,167,231,0.35)]">About Zen Typer</h2>
           <Button

--- a/src/components/HelpSheet.tsx
+++ b/src/components/HelpSheet.tsx
@@ -57,7 +57,7 @@ const HelpSheet = React.memo((props: HelpSheetProps) => {
 
   return (
     <div
-      className="fixed inset-0 z-[1100] flex items-center justify-center bg-base/80 backdrop-blur-md"
+      className="overlay-backdrop fixed inset-0 z-[1100] flex items-center justify-center bg-base/80 backdrop-blur-md"
       role="presentation"
       tabIndex={-1}
       onClick={(e) => {
@@ -76,7 +76,7 @@ const HelpSheet = React.memo((props: HelpSheetProps) => {
       }}
     >
       <div
-        className="glass rounded-2xl p-8 max-w-lg w-full mx-4 max-h-[85vh] overflow-y-auto overscroll-contain"
+        className="overlay-card glass rounded-2xl p-8 max-w-lg w-full mx-4 max-h-[85vh] overflow-y-auto overscroll-contain"
         role="dialog"
         aria-modal="true"
         aria-labelledby="help-title"

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -24,12 +24,12 @@ const IconButton: React.FC<IconButtonProps> = ({
     ? 'h-10 px-4 rounded-2xl gap-2'
     : 'h-10 w-10 rounded-xl';
   const palette = variant === 'subtlePill'
-    ? 'border-muted/25 text-muted bg-transparent hover:bg-surface/60 hover:text-text hover:border-iris/35 focus-visible:ring-1 focus-visible:ring-iris/45 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
+    ? 'border-muted/25 text-muted bg-transparent hover:bg-surface/60 hover:text-text hover:border-tint/35 focus-visible:ring-1 focus-visible:ring-tint/45 focus-visible:ring-offset-2 focus-visible:ring-offset-base'
     : active
-    ? 'bg-iris/20 border-iris/60 text-iris shadow-[0_8px_16px_-10px_rgba(196,167,231,0.45)]'
+    ? 'bg-tint/20 border-tint/60 text-tint shadow-[0_8px_16px_-10px_color-mix(in_oklab,var(--theme-accent)_45%,transparent)]'
     : subtle
-    ? 'border-muted/25 text-muted bg-transparent hover:bg-iris/10 hover:border-iris/35 hover:text-text'
-    : 'border-muted/35 text-muted hover:border-iris/45 hover:text-text';
+    ? 'border-muted/25 text-muted bg-transparent hover:bg-tint/10 hover:border-tint/35 hover:text-text'
+    : 'border-muted/35 text-muted hover:border-tint/45 hover:text-text';
 
   return (
     <Button

--- a/src/components/PauseMenu.tsx
+++ b/src/components/PauseMenu.tsx
@@ -114,7 +114,7 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onReset, mode: _mode }) => {
 
   return (
     <div
-      className="fixed inset-0 z-[2000] flex items-center justify-center bg-base/80 backdrop-blur-md"
+      className="overlay-backdrop fixed inset-0 z-[2000] flex items-center justify-center bg-base/80 backdrop-blur-md"
       role="dialog"
       aria-modal="true"
       aria-labelledby="pause-title"
@@ -129,7 +129,7 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onReset, mode: _mode }) => {
         <span className="sr-only">Dismiss pause menu</span>
       </Button>
       <div
-        className={`glass rounded-2xl p-8 max-w-lg w-full mx-4 max-h-[85vh] overflow-y-auto overscroll-contain relative z-10 ${showSettings ? 'settings-shell settings-scroll' : ''}`}
+        className={`overlay-card glass rounded-2xl p-8 max-w-lg w-full mx-4 max-h-[85vh] overflow-y-auto overscroll-contain relative z-10 ${showSettings ? 'settings-shell settings-scroll' : ''}`}
         tabIndex={-1}
       >
         {!showSettings && !showAbout ? (

--- a/src/components/PauseMenu.tsx
+++ b/src/components/PauseMenu.tsx
@@ -134,13 +134,13 @@ const PauseMenu: React.FC<PauseMenuProps> = ({ onReset, mode: _mode }) => {
       >
         {!showSettings && !showAbout ? (
           <>
-            <h2 id="pause-title" className="text-2xl font-sans text-foam mb-6">Paused</h2>
-            
+            <h2 id="pause-title" className="text-2xl font-sans text-tint mb-6">Paused</h2>
+
             <div className="space-y-3">
               <Button
                 onClick={closeMenu}
                 variant="outline"
-                className="w-full px-6 py-3 bg-iris/20 hover:bg-iris/30 border-iris/40 text-iris font-sans transition-all hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-12px] hover:shadow-iris/50 focus-visible:ring-2 focus-visible:ring-iris/50 active:scale-[0.98]"
+                className="w-full px-6 py-3 bg-tint/20 hover:bg-tint/30 border-tint/45 text-tint font-sans transition-all hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-12px_color-mix(in_oklab,var(--theme-accent)_55%,transparent)] focus-visible:ring-2 focus-visible:ring-tint/50 active:scale-[0.98]"
               >
                 Resume
               </Button>

--- a/src/components/QuoteTyper.tsx
+++ b/src/components/QuoteTyper.tsx
@@ -665,32 +665,32 @@ const QuoteTyper: React.FC<QuoteTyperProps> = ({
         {isComplete && (
           <div className="glass rounded-2xl p-8 text-center completion-pulse">
             <div className="stagger-fade-in">
-              <h2 className="text-2xl font-sans text-foam mb-6">
+              <h2 className="text-2xl font-sans text-tint mb-6">
                 Breathe. Begin again.
               </h2>
               <div className="flex items-stretch justify-center gap-10 mb-6">
                 <div>
                   <div className="text-xs uppercase tracking-widest text-muted/80 mb-1">WPM</div>
-                  <div className="text-5xl font-mono text-gold tabular-nums leading-none">
+                  <div className="text-5xl font-mono text-tint tabular-nums leading-none">
                     <AnimatedNumber value={wpmValue} showImprovement={true} />
                   </div>
                 </div>
-                <div className="w-px self-stretch bg-iris/15" aria-hidden="true" />
+                <div className="w-px self-stretch bg-tint/20" aria-hidden="true" />
                 <div>
                   <div className="text-xs uppercase tracking-widest text-muted/80 mb-1">Accuracy</div>
-                  <div className="text-5xl font-mono text-rose tabular-nums leading-none">
+                  <div className="text-5xl font-mono text-tint2 tabular-nums leading-none">
                     <AnimatedNumber value={accuracyValue} format={(v) => `${Math.round(v)}%`} />
                   </div>
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-4 text-left text-sm mb-6">
-                <div className="rounded-xl border border-iris/12 bg-surface/40 p-4">
+                <div className="rounded-xl border border-tint/15 bg-surface/40 p-4">
                   <div className="text-xs uppercase tracking-widest text-muted/80 mb-2">Errors</div>
                   <div className="font-mono text-text/90">Slip: {errorCounts.slip}</div>
                   <div className="font-mono text-text/90">Skip: {errorCounts.skip}</div>
                   <div className="font-mono text-text/90">Extra: {errorCounts.extra}</div>
                 </div>
-                <div className="rounded-xl border border-iris/12 bg-surface/40 p-4">
+                <div className="rounded-xl border border-tint/15 bg-surface/40 p-4">
                   <div className="text-xs uppercase tracking-widest text-muted/80 mb-2">Totals</div>
                   <div className="font-mono text-text/90">Characters: {totalTyped}</div>
                   <div className="font-mono text-text/90">Correct: {correctChars}</div>
@@ -700,21 +700,21 @@ const QuoteTyper: React.FC<QuoteTyperProps> = ({
               <div className="flex flex-wrap items-center justify-center gap-3">
                 <Button
                   onClick={handleReset}
-                  className="bg-iris/90 hover:bg-iris font-semibold shadow-[0_8px_24px_-10px_color-mix(in_oklab,var(--rp-iris)_60%,transparent)]"
+                  className="bg-tint/90 hover:bg-tint text-base font-semibold text-[color-mix(in_oklab,var(--rp-base)_88%,black_12%)] shadow-[0_8px_24px_-10px_color-mix(in_oklab,var(--theme-accent)_60%,transparent)]"
                 >
                   Type Again
                 </Button>
                 <Button
                   onClick={() => triggerNewQuote()}
                   variant="outline"
-                  className="border-foam/40 text-foam hover:bg-foam/15"
+                  className="border-tint2/45 text-tint2 hover:bg-tint2/15"
                 >
                   New Quote
                 </Button>
                 <Button
                   onClick={() => toggleAutoAdvance(!autoAdvance)}
                   variant="ghost"
-                  className={autoAdvance ? 'text-foam hover:bg-foam/10' : 'text-muted hover:bg-overlay/50 hover:text-text'}
+                  className={autoAdvance ? 'text-tint2 hover:bg-tint2/10' : 'text-muted hover:bg-overlay/50 hover:text-text'}
                 >
                   {autoAdvance ? 'Auto Next: On' : 'Auto Next: Off'}
                 </Button>

--- a/src/components/QuoteTyper.tsx
+++ b/src/components/QuoteTyper.tsx
@@ -112,6 +112,12 @@ const QuoteTyper: React.FC<QuoteTyperProps> = ({
     return Math.round((correctChars / totalTyped) * 100);
   }, [correctChars, totalTyped]);
 
+  // Overall progress through the quote (0–100)
+  const progressPct = useMemo(
+    () => Math.max(0, Math.min(100, Math.round((cursor / Math.max(1, activeQuote.length)) * 100))),
+    [cursor, activeQuote.length],
+  );
+
   // Chunk helpers
   const toggleAutoAdvance = useCallback((enabled: boolean) => {
     setAutoAdvance(enabled);
@@ -527,35 +533,51 @@ const QuoteTyper: React.FC<QuoteTyperProps> = ({
     return () => window.removeEventListener('keydown', handler as any, { capture: true } as any);
   }, []);
 
-  // Render character span
+  // Render a single character span \u2014 clean, borderless state system.
   const renderChar = (char: string, index: number) => {
     const isTyped = index < cursor;
     const isCurrent = index === cursor;
     const hasError = errors.has(index);
     const typedChar = typedChars[index];
 
-    let className = 'quote-char inline-block px-[2px] py-1 font-mono text-lg transition-all ';
+    let state = 'pending';
+    if (isCurrent) state = 'current';
+    else if (isTyped) state = hasError ? 'error' : 'correct';
 
-    if (isCurrent) {
-      className += 'bg-iris/20 border-b-2 border-iris zen-caret ';
-    } else if (isTyped) {
-      if (hasError) {
-        className += 'error underline decoration-wavy underline-offset-4 border-b-2 border-dashed border-love/70 ';
-      } else {
-        className += 'correct border-b-2 border-foam/70 ';
-      }
-    } else {
-      className += 'pending border-b-2 border-dotted border-muted/40 ';
-    }
-
-    // Handle spaces
     const displayChar = char === ' ' ? '\u00A0' : char;
+    const shown = isTyped && typedChar ? (hasError ? typedChar : displayChar) : displayChar;
 
     return (
-      <span key={index} className={className} style={{ animationDelay: `${index * 0.01}s` }}>
-        {isTyped && typedChar ? (hasError ? typedChar : displayChar) : displayChar}
+      <span key={index} className={`quote-char font-mono ${state}`} data-state={state}>
+        {shown}
       </span>
     );
+  };
+
+  // Render a range of the quote, grouping non-space runs into unbreakable words
+  // (.quote-word) so the typing surface never wraps in the middle of a word.
+  const renderRange = (start: number, end: number): React.ReactNode[] => {
+    const nodes: React.ReactNode[] = [];
+    let word: React.ReactNode[] = [];
+    let wordKey = start;
+    const flush = () => {
+      if (word.length) {
+        nodes.push(<span key={`w${wordKey}`} className="quote-word">{word}</span>);
+        word = [];
+      }
+    };
+    for (let i = start; i < end; i++) {
+      const ch = activeQuote[i] ?? '';
+      if (ch === ' ') {
+        flush();
+        nodes.push(renderChar(' ', i));
+      } else {
+        if (word.length === 0) wordKey = i;
+        word.push(renderChar(ch, i));
+      }
+    }
+    flush();
+    return nodes;
   };
 
   const containerClass = isComplete
@@ -612,126 +634,91 @@ const QuoteTyper: React.FC<QuoteTyperProps> = ({
           </div>
         )}
         {/* Quote display */}
-        <div className="glass rounded-2xl p-8 mb-8">
-          <div className="text-2xl leading-relaxed mb-4 select-none">
-            {chunks.length === 0 && activeQuote.split('').map((char, i) => renderChar(char, i))}
+        <div className="glass quote-card rounded-2xl px-8 pt-8 pb-7 mb-6">
+          <div key={activeQuote} className="quote-body text-2xl leading-relaxed select-none">
+            {chunks.length === 0 && renderRange(0, activeQuote.length)}
             {chunks.length > 0 && chunks.map((c, ci) => (
-              <div key={ci} className={`mb-2 relative ${ci === currentChunkIndex ? 'opacity-100' : 'opacity-80'}`}>
-                <span>
-                  {activeQuote.slice(c.start, c.end).split('').map((char, i) => renderChar(char, c.start + i))}
-                </span>
-                {/* Pace band under current chunk */}
-                {ci === currentChunkIndex && (
-                  <div className="mt-2 h-1 w-full bg-overlay/40 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-foam/60"
-                      style={{
-                        width: `${Math.max(0, Math.min(100, ((cursor - c.start) / Math.max(1, c.end - c.start)) * 100))}%`,
-                      }}
-                    />
-                  </div>
-                )}
+              <div key={ci} className="quote-line">
+                {renderRange(c.start, c.end)}
               </div>
             ))}
           </div>
           {activeAuthor && (
-            <div className="text-right text-muted text-lg">
-              <span aria-hidden="true">-</span> {activeAuthor}
+            <div className="text-right text-muted text-lg mt-5">
+              <span aria-hidden="true">—</span> {activeAuthor}
             </div>
           )}
-        </div>
-
-        {/* Stats display */}
-        <div className="glass rounded-xl p-6 mb-8 stagger-fade-in">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
-            <div>
-              <div className="text-sm text-muted mb-1">Progress</div>
-              <div className="text-2xl font-mono text-foam">
-                <AnimatedNumber
-                  value={Math.floor((cursor / activeQuote.length) * 100)}
-                  format={(v) => `${Math.round(v)}%`}
-                  showImprovement={true}
-                />
-              </div>
-            </div>
-            <div>
-              <div className="text-sm text-muted mb-1">WPM</div>
-              <div className="text-2xl font-mono text-gold">
-                {startTime && !isComplete ? '-' : (
-                  <AnimatedNumber
-                    value={wpmValue}
-                    showImprovement={true}
-                  />
-                )}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm text-muted mb-1">Accuracy</div>
-              <div className="text-2xl font-mono text-rose">
-                <AnimatedNumber
-                  value={totalTyped === 0 ? 100 : accuracyValue}
-                  format={(v) => `${Math.round(v)}%`}
-                  showImprovement={false}
-                />
-              </div>
-            </div>
-            <div>
-              <div className="text-sm text-muted mb-1">Errors</div>
-              <div className="text-2xl font-mono text-love">
-                <AnimatedNumber
-                  value={errors.size}
-                  showImprovement={false}
-                />
-              </div>
-            </div>
+          {/* Single, elegant progress indicator (live stats live in the StatsBar HUD) */}
+          <div
+            className="quote-progress-track mt-6"
+            role="progressbar"
+            aria-label="Quote progress"
+            aria-valuenow={progressPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div className="quote-progress-fill" style={{ width: `${progressPct}%` }} />
           </div>
         </div>
 
         {/* Completion message */}
         {isComplete && (
-          <div className="glass rounded-xl p-6 text-center animate-fade-in completion-pulse">
-            <h2 className="text-2xl font-sans text-foam mb-2">
-              Breathe. Begin again.
-            </h2>
-            <p className="text-muted mb-4">
-              {wpmValue} WPM • {accuracyValue}% accuracy
-            </p>
-            <div className="grid grid-cols-2 gap-4 text-left text-sm mb-4">
-              <div className="glass rounded p-3">
-                <div className="text-xs text-muted mb-1">Errors</div>
-                <div className="font-mono">Slip: {errorCounts.slip}</div>
-                <div className="font-mono">Skip: {errorCounts.skip}</div>
-                <div className="font-mono">Extra: {errorCounts.extra}</div>
+          <div className="glass rounded-2xl p-8 text-center completion-pulse">
+            <div className="stagger-fade-in">
+              <h2 className="text-2xl font-sans text-foam mb-6">
+                Breathe. Begin again.
+              </h2>
+              <div className="flex items-stretch justify-center gap-10 mb-6">
+                <div>
+                  <div className="text-xs uppercase tracking-widest text-muted/80 mb-1">WPM</div>
+                  <div className="text-5xl font-mono text-gold tabular-nums leading-none">
+                    <AnimatedNumber value={wpmValue} showImprovement={true} />
+                  </div>
+                </div>
+                <div className="w-px self-stretch bg-iris/15" aria-hidden="true" />
+                <div>
+                  <div className="text-xs uppercase tracking-widest text-muted/80 mb-1">Accuracy</div>
+                  <div className="text-5xl font-mono text-rose tabular-nums leading-none">
+                    <AnimatedNumber value={accuracyValue} format={(v) => `${Math.round(v)}%`} />
+                  </div>
+                </div>
               </div>
-              <div className="glass rounded p-3">
-                <div className="text-xs text-muted mb-1">Totals</div>
-                <div className="font-mono">Characters typed: {totalTyped}</div>
-                <div className="font-mono">Correct chars: {correctChars}</div>
-                <div className="font-mono">Streak time: {streakTimeSec}s</div>
+              <div className="grid grid-cols-2 gap-4 text-left text-sm mb-6">
+                <div className="rounded-xl border border-iris/12 bg-surface/40 p-4">
+                  <div className="text-xs uppercase tracking-widest text-muted/80 mb-2">Errors</div>
+                  <div className="font-mono text-text/90">Slip: {errorCounts.slip}</div>
+                  <div className="font-mono text-text/90">Skip: {errorCounts.skip}</div>
+                  <div className="font-mono text-text/90">Extra: {errorCounts.extra}</div>
+                </div>
+                <div className="rounded-xl border border-iris/12 bg-surface/40 p-4">
+                  <div className="text-xs uppercase tracking-widest text-muted/80 mb-2">Totals</div>
+                  <div className="font-mono text-text/90">Characters: {totalTyped}</div>
+                  <div className="font-mono text-text/90">Correct: {correctChars}</div>
+                  <div className="font-mono text-text/90">Streak time: {streakTimeSec}s</div>
+                </div>
               </div>
-            </div>
-            <div className="flex items-center justify-center gap-3">
-              <Button
-                onClick={() => triggerNewQuote()}
-                variant="outline"
-                className="bg-gold/20 hover:bg-gold/30 border-gold/40 text-gold"
-              >
-                New Quote
-              </Button>
-              <Button
-                onClick={() => toggleAutoAdvance(!autoAdvance)}
-                variant="outline"
-                className={autoAdvance ? 'bg-surface/60 hover:bg-surface/80 border-muted/30 text-text' : 'bg-foam/20 hover:bg-foam/30 border-foam/40 text-foam'}
-              >
-                {autoAdvance ? 'Disable Auto Next' : 'Enable Auto Next'}
-              </Button>
-              <Button
-                onClick={handleReset}
-                variant="outline"
-                className="bg-iris/20 hover:bg-iris/30 border-iris/40 text-iris"
-              >
-                Type Again
-              </Button>
+              <div className="flex flex-wrap items-center justify-center gap-3">
+                <Button
+                  onClick={handleReset}
+                  className="bg-iris/90 hover:bg-iris font-semibold shadow-[0_8px_24px_-10px_color-mix(in_oklab,var(--rp-iris)_60%,transparent)]"
+                >
+                  Type Again
+                </Button>
+                <Button
+                  onClick={() => triggerNewQuote()}
+                  variant="outline"
+                  className="border-foam/40 text-foam hover:bg-foam/15"
+                >
+                  New Quote
+                </Button>
+                <Button
+                  onClick={() => toggleAutoAdvance(!autoAdvance)}
+                  variant="ghost"
+                  className={autoAdvance ? 'text-foam hover:bg-foam/10' : 'text-muted hover:bg-overlay/50 hover:text-text'}
+                >
+                  {autoAdvance ? 'Auto Next: On' : 'Auto Next: Off'}
+                </Button>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -144,7 +144,7 @@ const structuredData = [
 <script is:inline>
   (function () {
     try {
-      var themeClasses = ["theme-void", "theme-forest", "theme-ocean", "theme-cosmic"];
+      var themeClasses = ["theme-void", "theme-forest", "theme-ocean", "theme-cosmic", "theme-ember", "theme-sakura", "theme-aurora", "theme-glacier"];
       var root = document.documentElement;
 
       var raw = null;

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -4,7 +4,7 @@ import KeyboardHint from './KeyboardHint';
 const SiteFooter: React.FC = React.memo(() => {
   return (
     <footer className="fixed bottom-0 left-0 right-0 z-30 pointer-events-none">
-      <div className="mx-auto max-w-6xl px-6 pb-5">
+      <div className="mx-auto max-w-6xl px-6 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
         {/* Keyboard shortcuts hint row */}
         <div className="pointer-events-auto flex items-center justify-center gap-4 mb-3 opacity-60 hover:opacity-100 transition-opacity">
           <KeyboardHint keyLabel="Tab" description="Switch mode" />

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -108,14 +108,14 @@ const SiteHeader: React.FC<SiteHeaderProps> = ({ mode }) => {
   };
 
   const navLinkClass = (active: boolean) =>
-    `inline-flex items-center justify-center px-3.5 h-10 rounded-full text-sm font-medium border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-iris/70 ${
+    `inline-flex items-center justify-center px-3.5 h-10 rounded-full text-sm font-medium border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tint/70 ${
       active
-        ? 'bg-iris/20 border-iris/60 text-text shadow-sm'
+        ? 'bg-tint/20 border-tint/60 text-text shadow-sm'
         : 'border-muted/30 text-muted hover:text-text hover:border-muted/50'
     }`;
 
   const primaryButtonClass =
-    'group inline-flex items-center justify-center gap-2 px-5 h-11 min-w-[10rem] rounded-xl border border-iris/25 bg-[color:var(--rp-surface)]/45 text-sm font-medium text-foam/90 transition-colors shadow-[0_8px_20px_-16px_rgba(102,76,255,0.45)] hover:bg-[color:var(--rp-surface)]/60 hover:border-iris/40 hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-iris/55';
+    'group inline-flex items-center justify-center gap-2 px-5 h-11 min-w-[10rem] rounded-xl border border-tint/25 bg-[color:var(--rp-surface)]/45 text-sm font-medium text-tint transition-colors shadow-[0_8px_20px_-16px_color-mix(in_oklab,var(--theme-accent)_45%,transparent)] hover:bg-[color:var(--rp-surface)]/60 hover:border-tint/45 hover:text-tint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tint/55';
 
   const quickSettingIcons = {
     reducedMotion: (

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -89,7 +89,7 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
 
   return (
     <div className="stats-cq">
-      <div className="stats-bar fixed bottom-[calc(6.5rem+env(safe-area-inset-bottom))] md:bottom-[calc(5.5rem+env(safe-area-inset-bottom))] left-1/2 transform -translate-x-1/2 z-40 w-full max-w-4xl px-4" data-stats-bar>
+      <div className="stats-bar fixed bottom-[calc(6.5rem_+_env(safe-area-inset-bottom))] md:bottom-[calc(5.5rem_+_env(safe-area-inset-bottom))] left-1/2 transform -translate-x-1/2 z-40 w-full max-w-4xl px-4" data-stats-bar>
         <div className="rounded-full px-8 py-3.5 flex flex-wrap items-center justify-center gap-8 
                         bg-surface/40 backdrop-blur-xl border border-iris/20
                         shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(156,207,216,0.1)]

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -89,7 +89,7 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
 
   return (
     <div className="stats-cq">
-      <div className="stats-bar fixed bottom-24 md:bottom-20 left-1/2 transform -translate-x-1/2 z-40 w-full max-w-4xl px-4" data-stats-bar>
+      <div className="stats-bar fixed bottom-[calc(6.5rem+env(safe-area-inset-bottom))] md:bottom-[calc(5.5rem+env(safe-area-inset-bottom))] left-1/2 transform -translate-x-1/2 z-40 w-full max-w-4xl px-4" data-stats-bar>
         <div className="rounded-full px-8 py-3.5 flex flex-wrap items-center justify-center gap-8 
                         bg-surface/40 backdrop-blur-xl border border-iris/20
                         shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(156,207,216,0.1)]

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -90,16 +90,16 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
   return (
     <div className="stats-cq">
       <div className="stats-bar fixed bottom-[calc(6.5rem_+_env(safe-area-inset-bottom))] md:bottom-[calc(5.5rem_+_env(safe-area-inset-bottom))] left-1/2 transform -translate-x-1/2 z-40 w-full max-w-4xl px-4" data-stats-bar>
-        <div className="rounded-full px-8 py-3.5 flex flex-wrap items-center justify-center gap-8 
-                        bg-surface/40 backdrop-blur-xl border border-iris/20
-                        shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(156,207,216,0.1)]
-                        transition-all duration-300 hover:bg-surface/50 hover:border-iris/30">
+        <div className="rounded-full px-8 py-3.5 flex flex-wrap items-center justify-center gap-8
+                        bg-surface/40 backdrop-blur-xl border border-tint/25
+                        shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.06)]
+                        transition-all duration-300 hover:bg-surface/50 hover:border-tint/35">
           {displayedMetrics.map((key) => {
             if (key === 'time') {
               return (
                 <div key={key} className="flex items-center gap-2.5 px-1">
                   <span className="text-[10px] text-muted/80 uppercase tracking-widest font-medium">Time</span>
-                  <span className="text-xl font-mono text-foam font-semibold tabular-nums">
+                  <span className="text-xl font-mono text-tint font-semibold tabular-nums">
                     {formatTime((data.time as number) || 0)}
                   </span>
                 </div>
@@ -110,7 +110,7 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
               return (
                 <div key={key} className="flex items-center gap-2.5 px-1">
                   <span className="text-[10px] text-muted/80 uppercase tracking-widest font-medium">Words</span>
-                  <span className="text-xl font-mono text-gold font-semibold tabular-nums">
+                  <span className="text-xl font-mono text-tint2 font-semibold tabular-nums">
                     {data.words ?? 0}
                   </span>
                 </div>
@@ -122,7 +122,7 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
               return (
                 <div key={key} className="flex items-center gap-2.5 px-1">
                   <span className="text-[10px] text-muted/80 uppercase tracking-widest font-medium">WPM</span>
-                  <span className="text-xl font-mono text-rose font-semibold tabular-nums">
+                  <span className="text-xl font-mono text-tint font-semibold tabular-nums">
                     {value !== undefined ? value : '—'}
                   </span>
                 </div>
@@ -134,7 +134,7 @@ const StatsBar: React.FC<StatsBarProps> = ({ mode, visible, metrics }) => {
               return (
                 <div key={key} className="flex items-center gap-2.5 px-1">
                   <span className="text-[10px] text-muted/80 uppercase tracking-widest font-medium">Accuracy</span>
-                  <span className="text-xl font-mono text-iris font-semibold tabular-nums">
+                  <span className="text-xl font-mono text-tint2 font-semibold tabular-nums">
                     {value !== undefined ? `${value}%` : '—'}
                   </span>
                 </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -4,7 +4,7 @@ import { useMotionPreference } from '../hooks/useMotionPreference';
 import IconButton from './IconButton';
 import { Button } from '@/components/ui/button';
 
-type Theme = 'Void' | 'Forest' | 'Ocean' | 'Cosmic';
+type Theme = 'Void' | 'Forest' | 'Ocean' | 'Cosmic' | 'Ember' | 'Sakura' | 'Aurora' | 'Glacier';
 
 interface ThemeToggleProps {
   className?: string;
@@ -14,7 +14,7 @@ type ViewTransitionStart = (cb: () => void) => { finished: Promise<void>; ready:
 
 const applyThemeClass = (newTheme: Theme) => {
   const root = document.documentElement;
-  root.classList.remove('theme-void', 'theme-forest', 'theme-ocean', 'theme-cosmic');
+  root.classList.remove('theme-void', 'theme-forest', 'theme-ocean', 'theme-cosmic', 'theme-ember', 'theme-sakura', 'theme-aurora', 'theme-glacier');
   root.classList.add(`theme-${newTheme.toLowerCase()}`);
 };
 
@@ -184,7 +184,7 @@ const ThemeToggle: React.FC<ThemeToggleProps> = ({ className = '' }) => {
     setIsOpen(false);
   };
 
-  const themes: Theme[] = ['Void', 'Forest', 'Ocean', 'Cosmic'];
+  const themes: Theme[] = ['Void', 'Cosmic', 'Aurora', 'Ocean', 'Glacier', 'Forest', 'Ember', 'Sakura'];
 
   return (
     <div className={`relative ${className}`.trim()}>

--- a/src/components/ZenCanvas.tsx
+++ b/src/components/ZenCanvas.tsx
@@ -271,9 +271,17 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
   useEffect(() => { statsRef.current = stats; }, [stats]);
 
   useEffect(() => {
-    const updateTheme = () => {
+    // Prefer the theme NAME carried on the themeChanged event. applyTheme()
+    // flips the <html> class inside a View Transition (async), so reading
+    // classList synchronously when the event fires returns the PREVIOUS theme —
+    // which made the canvas ambience (leaves/bubbles) lag one selection behind.
+    const updateTheme = (e?: Event) => {
       const root = document.documentElement;
-      const themeName = ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n)) || 'void';
+      const detail = e && (e as CustomEvent).detail;
+      const named = typeof detail === 'string' ? detail.toLowerCase() : null;
+      const themeName = named
+        || ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n))
+        || 'void';
       themeRef.current = {
         isCosmic: themeName === 'cosmic',
         isForest: themeName === 'forest',
@@ -341,7 +349,12 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       const s = (e as CustomEvent).detail as Settings;
       settingsRef.current = s;
       const root = document.documentElement;
-      const themeName = ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n)) || 'void';
+      // Use the theme from the settings payload (set before the class flips via
+      // the View Transition) so the ambience switches immediately, not a step late.
+      const named = s && typeof s.theme === 'string' ? s.theme.toLowerCase() : null;
+      const themeName = named
+        || ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n))
+        || 'void';
       themeRef.current = {
         isCosmic: themeName === 'cosmic',
         isForest: themeName === 'forest',
@@ -963,7 +976,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
 
   // Handle canvas resize
   useEffect(() => {
-    const regenerateThemeParticles = () => {
+    const regenerateThemeParticles = (e?: Event) => {
       const canvas = canvasRef.current;
       if (!canvas) return;
 
@@ -988,8 +1001,12 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
 
       const ctx = (backCtxRef.current as any) || canvas.getContext('2d');
 
-      // Regenerate particles for theme changes
-      const isCosmic = document.documentElement.classList.contains('theme-cosmic');
+      // Regenerate particles for theme changes. On a themeChanged event the
+      // <html> class hasn't flipped yet (View Transition), so trust the event's
+      // theme name; otherwise (resize/font) read the already-stable class.
+      const detail = e && (e as CustomEvent).detail;
+      const named = typeof detail === 'string' ? detail.toLowerCase() : null;
+      const isCosmic = named ? named === 'cosmic' : document.documentElement.classList.contains('theme-cosmic');
       const perfMode = !!getSettingsSnapshot().performanceMode;
       
       // Reset all theme particles

--- a/src/components/ZenCanvas.tsx
+++ b/src/components/ZenCanvas.tsx
@@ -152,7 +152,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
   const markersRef = useRef<number[]>([]);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const statsRef = useRef(stats);
-  const themeRef = useRef({ isCosmic: false, isForest: false, isOcean: false });
+  const themeRef = useRef({ isCosmic: false, isForest: false, isOcean: false, name: 'void' });
 
   const getSettingsSnapshot = (): Settings => {
     if (!settingsRef.current) {
@@ -273,10 +273,12 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
   useEffect(() => {
     const updateTheme = () => {
       const root = document.documentElement;
+      const themeName = ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n)) || 'void';
       themeRef.current = {
-        isCosmic: root.classList.contains('theme-cosmic'),
-        isForest: root.classList.contains('theme-forest'),
-        isOcean: root.classList.contains('theme-ocean'),
+        isCosmic: themeName === 'cosmic',
+        isForest: themeName === 'forest',
+        isOcean: themeName === 'ocean',
+        name: themeName,
       };
     };
     updateTheme();
@@ -339,10 +341,12 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       const s = (e as CustomEvent).detail as Settings;
       settingsRef.current = s;
       const root = document.documentElement;
+      const themeName = ['cosmic', 'forest', 'ocean', 'ember', 'sakura', 'aurora', 'glacier', 'void'].find((n) => root.classList.contains('theme-' + n)) || 'void';
       themeRef.current = {
-        isCosmic: root.classList.contains('theme-cosmic'),
-        isForest: root.classList.contains('theme-forest'),
-        isOcean: root.classList.contains('theme-ocean'),
+        isCosmic: themeName === 'cosmic',
+        isForest: themeName === 'forest',
+        isOcean: themeName === 'ocean',
+        name: themeName,
       };
     };
     const onToggleBreath = () => {
@@ -563,7 +567,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
 
     const styleCache = styleCacheRef.current ?? { ...FALLBACK_STYLE_CACHE, typingFont: fontFamily };
     const { rpText, moss, leaf: leafColor, typingFont, rpFoam, rpGold, rpLove, rpIris } = styleCache;
-    const { isCosmic, isForest, isOcean } = themeRef.current;
+    const { isCosmic, isForest, isOcean, name: themeName } = themeRef.current;
     const sNow = getSettingsSnapshot();
     const perfMode = !!sNow.performanceMode;
     
@@ -800,9 +804,11 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
 
       // Theme-aware color tint
       let tokenColor = rpText;
-      if (isCosmic) tokenColor = rpIris;
-      else if (isOcean) tokenColor = rpFoam;
-      else if (isForest) tokenColor = leafColor;
+      if (themeName === 'cosmic') tokenColor = rpIris;
+      else if (themeName === 'ocean' || themeName === 'aurora' || themeName === 'glacier') tokenColor = rpFoam;
+      else if (themeName === 'forest') tokenColor = leafColor;
+      else if (themeName === 'ember') tokenColor = rpGold;
+      else if (themeName === 'sakura') tokenColor = rpLove;
 
       // Entrance "pop": spring up from 0.84 → ~1.0 with a soft overshoot
       // (easeOutBack), so each word feels like it lands rather than shrinks in.

--- a/src/components/ZenCanvas.tsx
+++ b/src/components/ZenCanvas.tsx
@@ -1123,9 +1123,9 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
         className="zen-input bottom-[18vh] left-1/2 -translate-x-1/2
                    w-[90vw] max-w-xl px-6 py-4 text-lg font-mono caret-accent
                    backdrop-blur-soft
-                   border border-iris/25 rounded-2xl
+                   border border-tint/30 rounded-2xl
                    text-text placeholder-muted tracking-wide
-                   focus:outline-none focus:border-iris/40"
+                   focus:outline-none focus:border-tint/50"
         placeholder="Type freely…"
         onChange={handleInput}
         onKeyDown={handleKeyDown}

--- a/src/components/ZenCanvas.tsx
+++ b/src/components/ZenCanvas.tsx
@@ -24,6 +24,7 @@ interface Token {
   vy: number;
   swayAmp: number;
   swayFreq: number;
+  swayPhase: number;
   lifetime: number;
   maxLifetime: number;
   birth: number;
@@ -109,6 +110,9 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const tokensRef = useRef<Token[]>([]);
   const [inputValue, setInputValue] = useState('');
+  // Brief "active typing" flag that drives the input's commit-ripple animation.
+  const [isCommitting, setIsCommitting] = useState(false);
+  const commitPulseTimerRef = useRef<number | null>(null);
   // eslint-disable-next-line react-hooks/purity
   const [stats, setStats] = useState({ words: 0, chars: 0, startTime: Date.now() });
   const animationFrameRef = useRef<number | null>(null);
@@ -165,7 +169,6 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
     const id = activeDraftIdRef.current;
     if (!id || !draftDirtyRef.current) return;
     const text = transcriptRef.current;
-    console.log('[DEBUG] Saving draft - text:', text);
     try {
       await updateDraftBody(id, text);
       draftDirtyRef.current = false;
@@ -229,6 +232,18 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
     draftDirtyRef.current = true;
     scheduleDraftSave();
   }, [scheduleDraftSave]);
+
+  // Pulse the input on each word commit so it feels like a living instrument
+  // (drives the .zen-input ripple/breathe animations in globals.css).
+  const pulseInput = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    setIsCommitting(true);
+    if (commitPulseTimerRef.current !== null) window.clearTimeout(commitPulseTimerRef.current);
+    commitPulseTimerRef.current = window.setTimeout(() => {
+      setIsCommitting(false);
+      commitPulseTimerRef.current = null;
+    }, 700);
+  }, []);
 
   const computeStyleCache = useCallback(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
@@ -422,6 +437,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       vy: Math.min(80, Math.max(30, 45 + Math.random() * 35)),
       swayAmp: amp,
       swayFreq: 0.6 + Math.random() * 0.6,
+      swayPhase: Math.random() * Math.PI * 2,
       lifetime,
       maxLifetime: lifetime,
       birth: birthTime
@@ -456,10 +472,11 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       if (Math.random() < frac) spawnToken(word);
     }
     
+    pulseInput();
+
     // Update transcript
     transcriptRef.current += word + delimiter;
-    console.log('[DEBUG] Committed word:', word, 'with delimiter:', delimiter, 'transcript now:', transcriptRef.current);
-    
+
     // Record in ghost log
     const now = (Date.now() - sessionStartRef.current) / 1000;
     for (const ch of word) {
@@ -473,7 +490,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
     ghostLogRef.current = ghostLogRef.current.filter(ev => ev.t >= cutoff);
     
     markDraftDirty();
-  }, [spawnToken, markDraftDirty, ensureDraftInitialized]);
+  }, [spawnToken, markDraftDirty, ensureDraftInitialized, pulseInput]);
 
   // Handle input changes with proper controlled input pattern
   const handleInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -487,9 +504,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       // Extract the word (everything except the delimiter)
       const word = newValue.slice(0, -1);
       const delimiter = lastChar ?? ' ';
-      
-      console.log('[DEBUG] Committing word:', word, 'delimiter:', delimiter);
-      
+
       // Commit the word
       commitWord(word, delimiter);
       
@@ -525,9 +540,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
     
     if (e.key === 'Backspace' && inputValue.length === 0 && transcriptRef.current.length > 0) {
       // If input is empty and backspace is pressed, remove from transcript
-      const oldTranscript = transcriptRef.current;
       transcriptRef.current = transcriptRef.current.slice(0, -1);
-      console.log('[DEBUG] Backspace on empty input - removed char from transcript, was:', oldTranscript, 'now:', transcriptRef.current);
       markDraftDirty();
     }
   }, [inputValue, commitWord, markDraftDirty]);
@@ -752,33 +765,34 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       const easeOut = 1 - Math.pow(1 - ageProgress, 2); // Quadratic ease-out
       token.y -= (token.vy / 60) * (1 - easeOut * 0.3); // Slow down as it rises
       
-      // Add horizontal sway if not reduced motion
+      // Add horizontal sway if not reduced motion. Two layered sines with a
+      // per-token phase keep tokens from oscillating in mechanical unison.
       const effectiveAmp = (perfGuardRef.current || perfMode) ? 0 : token.swayAmp;
       if (!rm && effectiveAmp > 0) {
-        const swayOffset = Math.sin(age * token.swayFreq * 2 * Math.PI) * effectiveAmp;
-        token.x += swayOffset / 60;
+        const primary = Math.sin(age * token.swayFreq * 2 * Math.PI + token.swayPhase) * effectiveAmp;
+        const secondary = Math.sin(age * token.swayFreq * 0.55 * Math.PI + token.swayPhase * 1.7) * effectiveAmp * 0.4;
+        token.x += (primary + secondary) / 60;
       }
-      
+
       // Check if still on screen
       if (token.y < -50 || token.x < -50 || token.x > canvas.width + 50) {
         return; // Remove off-screen tokens
       }
-      
-      // Smooth opacity fade in and fade out
+
+      // Smooth opacity fade in (quick ease-out so the word "arrives") and a
+      // long, gentle ease-out fade as it rises and evaporates.
       let opacity = 1;
-      const fadeInDuration = 0.3; // Gentle fade in
-      const fadeOutStart = 0.65; // Start fading earlier for longer transition
-      
+      const fadeInDuration = 0.32;
+      const fadeOutStart = 0.6;
+
       if (age < fadeInDuration) {
-        // Cubic ease-in for smooth appearance
         const t = age / fadeInDuration;
-        opacity = t * t * t;
+        opacity = 1 - Math.pow(1 - t, 2); // ease-out: appears promptly
       } else if (ageProgress > fadeOutStart) {
-        // Long, gentle fade out
         const fadeProgress = (ageProgress - fadeOutStart) / (1 - fadeOutStart);
-        opacity = Math.pow(1 - fadeProgress, 3); // Cubic ease-out
+        opacity = Math.pow(1 - fadeProgress, 3); // cubic ease-out
       }
-      
+
       // Draw token with glow, scale, and theme tint
       ctx.save();
       const rawOpacity = Math.max(0, Math.min(1, opacity));
@@ -790,21 +804,28 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
       else if (isOcean) tokenColor = rpFoam;
       else if (isForest) tokenColor = leafColor;
 
-      // Scale-in effect: 1.0 → 1.12 over first 0.4s, then settle
-      const scaleAge = Math.min(1, age / 0.4);
-      const scale = 1 + (1 - scaleAge) * 0.12;
+      // Entrance "pop": spring up from 0.84 → ~1.0 with a soft overshoot
+      // (easeOutBack), so each word feels like it lands rather than shrinks in.
+      const entranceT = Math.min(1, age / 0.45);
+      let scale = 1;
+      if (!rm) {
+        const c1 = 1.70158;
+        const c3 = c1 + 1;
+        const back = 1 + c3 * Math.pow(entranceT - 1, 3) + c1 * Math.pow(entranceT - 1, 2);
+        scale = 0.84 + 0.16 * back;
+      }
 
       // Slight rotation sway for organic feel
-      const rotation = Math.sin(age * 1.5) * 0.02;
+      const rotation = rm ? 0 : Math.sin(age * 1.5 + token.swayPhase) * 0.02;
 
       ctx.translate(token.x, token.y);
       ctx.rotate(rotation);
       ctx.scale(scale, scale);
 
-      // Glow shadow — stronger when young
-      const glowStrength = rawOpacity * (1 - scaleAge * 0.6);
+      // Layered glow — luminous when young, settling as it ages
+      const glowStrength = rawOpacity * (1 - Math.min(1, age / 0.45) * 0.55);
       ctx.shadowColor = tokenColor;
-      ctx.shadowBlur = 8 + glowStrength * 18;
+      ctx.shadowBlur = 10 + glowStrength * 22;
       ctx.shadowOffsetX = 0;
       ctx.shadowOffsetY = 0;
 
@@ -815,7 +836,7 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
 
       // Second pass: crisp core text for readability
       ctx.shadowBlur = 0;
-      ctx.globalAlpha = rawOpacity * 0.9;
+      ctx.globalAlpha = rawOpacity * 0.92;
       ctx.fillStyle = rpText;
       ctx.fillText(token.text, 0, 0);
 
@@ -1042,6 +1063,13 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
     inputRef.current?.focus();
   }, []);
 
+  // Clear the commit-pulse timer on unmount
+  useEffect(() => () => {
+    if (commitPulseTimerRef.current !== null) {
+      window.clearTimeout(commitPulseTimerRef.current);
+    }
+  }, []);
+
   return (
     <div className="relative w-full h-screen overflow-hidden">
       <canvas
@@ -1084,14 +1112,15 @@ const ZenCanvas: React.FC<ZenCanvasProps> = ({
         type="text"
         aria-label="Free-flow typing input"
         value={inputValue}
-        className="absolute bottom-[18vh] left-1/2 -translate-x-1/2 
+        data-typing={isCommitting ? 'true' : undefined}
+        style={{ position: 'absolute' }}
+        className="zen-input bottom-[18vh] left-1/2 -translate-x-1/2
                    w-[90vw] max-w-xl px-6 py-4 text-lg font-mono caret-accent
-                   bg-surface/70 backdrop-blur-soft shadow-soft
+                   backdrop-blur-soft
                    border border-iris/25 rounded-2xl
                    text-text placeholder-muted tracking-wide
-                   focus:outline-none focus:ring-2 focus:ring-iris/40 focus:border-iris/40
-                   transition-all duration-200"
-        placeholder="Type freely..."
+                   focus:outline-none focus:border-iris/40"
+        placeholder="Type freely…"
         onChange={handleInput}
         onKeyDown={handleKeyDown}
         autoComplete="off"

--- a/src/components/draft/DraftManager.tsx
+++ b/src/components/draft/DraftManager.tsx
@@ -334,7 +334,7 @@ export const DraftManager: React.FC<DraftManagerProps> = ({ isOpen, onClose }) =
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[1000] glass-theme" role="dialog" aria-modal="true">
+    <div className="overlay-backdrop fixed inset-0 z-[1000] glass-theme" role="dialog" aria-modal="true">
       <div className="pointer-events-none fixed inset-0 z-0 theme-layer">
         <div className="forest-rays" aria-hidden="true" />
         <div className="ocean-lights" aria-hidden="true" />
@@ -406,7 +406,7 @@ export const DraftManager: React.FC<DraftManagerProps> = ({ isOpen, onClose }) =
                     'group relative w-full text-left px-5 py-4 rounded-xl border transition-all bg-surface/45 flex flex-col items-stretch justify-start whitespace-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-iris/45 focus-visible:ring-offset-2 focus-visible:ring-offset-surface/60',
                     isActive
                       ? 'border-iris/55 bg-iris/20 shadow-[0_12px_28px_rgba(26,12,48,0.38)]'
-                      : 'border-muted/25 hover:border-iris/45 hover:bg-surface/60 hover:shadow-[0_10px_24px_rgba(26,12,48,0.32)]'
+                      : 'border-muted/25 hover:border-iris/45 hover:bg-surface/60 hover:-translate-y-0.5 hover:shadow-[0_10px_24px_rgba(26,12,48,0.32)]'
                   )}
                 >
                   <div className="flex w-full flex-col gap-2">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,46 +26,48 @@ const aboutUrl = `${siteUrl}/about/`;
 		/>
 	</head>
 	<body>
-		<main class="min-h-screen bg-base px-6 pb-32 pt-12 text-text">
-			<div class="mx-auto max-w-3xl space-y-10">
-				<nav aria-label="Primary" class="flex flex-wrap gap-4 text-sm text-muted">
-					<a class="text-foam hover:text-text" href="/">Home</a>
-					<a class="text-foam hover:text-text" href="/quote/">Quote mode</a>
-					<a class="text-foam hover:text-text" href="/zen/">Zen mode</a>
-					<a class="text-foam hover:text-text" href="/contact/">Contact</a>
-					<a class="text-foam hover:text-text" href="/privacy/">Privacy</a>
+		<main class="content-page px-6 pb-32 pt-16 text-text">
+			<div class="mx-auto max-w-3xl space-y-8">
+				<nav aria-label="Primary" class="content-nav">
+					<a href="/">Home</a>
+					<a href="/quote/">Quote mode</a>
+					<a href="/zen/">Zen mode</a>
+					<a href="/contact/">Contact</a>
+					<a href="/privacy/">Privacy</a>
 				</nav>
 
-				<header class="space-y-4 border-b border-iris/15 pb-8">
-					<p class="text-sm font-medium uppercase tracking-[0.28em] text-iris">About</p>
-					<h1 class="text-4xl font-semibold tracking-tight text-text md:text-5xl">About Zen Typer</h1>
-					<p class="text-lg leading-8 text-muted">
-						Zen Typer is a focused typing practice app built by Jonathan Reed for people who want a calmer way to improve rhythm, accuracy, and writing momentum.
-					</p>
-				</header>
+				<article class="glass content-prose rounded-2xl p-8 md:p-10 space-y-8 stagger-fade-in">
+					<header class="space-y-4 border-b border-iris/15 pb-7">
+						<p class="eyebrow text-sm font-medium uppercase tracking-[0.28em]">About</p>
+						<h1>About Zen Typer</h1>
+						<p class="!text-lg !leading-8">
+							Zen Typer is a focused typing practice app built by Jonathan Reed for people who want a calmer way to improve rhythm, accuracy, and writing momentum.
+						</p>
+					</header>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">Why it exists</h2>
-					<p>
-						Most typing tools are optimized for speed runs, leaderboards, and constant pressure. Zen Typer keeps the useful parts of typing practice, including quote prompts, WPM feedback, accuracy tracking, and session flow, while removing distractions that make practice feel noisy. The app is meant to work as a short warmup before deep work, a quiet drill for improving accuracy, or a small writing space when you need to get words moving.
-					</p>
-					<p>
-						Quote Mode gives a measured practice surface with curated passages and immediate feedback. Zen Mode opens a free-flow canvas where typed words drift through the screen and local session stats stay available without taking over the experience. The two modes support different needs, one for structured practice and one for open writing rhythm.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>Why it exists</h2>
+						<p>
+							Most typing tools are optimized for speed runs, leaderboards, and constant pressure. Zen Typer keeps the useful parts of typing practice, including quote prompts, WPM feedback, accuracy tracking, and session flow, while removing distractions that make practice feel noisy. The app is meant to work as a short warmup before deep work, a quiet drill for improving accuracy, or a small writing space when you need to get words moving.
+						</p>
+						<p>
+							Quote Mode gives a measured practice surface with curated passages and immediate feedback. Zen Mode opens a free-flow canvas where typed words drift through the screen and local session stats stay available without taking over the experience. The two modes support different needs, one for structured practice and one for open writing rhythm.
+						</p>
+					</section>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">Privacy and design principles</h2>
-					<p>
-						Zen Typer is intentionally lightweight. It does not require an account, login, or external writing service to practice. Settings, drafts, and session details are handled locally in the browser so the app can stay fast and private. The interface uses a dark visual system, accessible controls, reduced-motion support, and clear keyboard paths for people who want typing practice without a heavy dashboard.
-					</p>
-					<p>
-						The project is maintained as a small, practical tool. Updates focus on accuracy, accessibility, performance, and search clarity rather than adding features that make the experience feel crowded.
-					</p>
-					<p>
-						The public pages explain how the app works so people can decide whether it fits their practice routine before opening a typing session. They also give crawlers and assistive tools plain text context without changing the main app surface.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>Privacy and design principles</h2>
+						<p>
+							Zen Typer is intentionally lightweight. It does not require an account, login, or external writing service to practice. Settings, drafts, and session details are handled locally in the browser so the app can stay fast and private. The interface uses a dark visual system, accessible controls, reduced-motion support, and clear keyboard paths for people who want typing practice without a heavy dashboard.
+						</p>
+						<p>
+							The project is maintained as a small, practical tool. Updates focus on accuracy, accessibility, performance, and search clarity rather than adding features that make the experience feel crowded.
+						</p>
+						<p>
+							The public pages explain how the app works so people can decide whether it fits their practice routine before opening a typing session. They also give crawlers and assistive tools plain text context without changing the main app surface.
+						</p>
+					</section>
+				</article>
 			</div>
 		</main>
 	</body>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -26,46 +26,48 @@ const contactUrl = `${siteUrl}/contact/`;
 		/>
 	</head>
 	<body>
-		<main class="min-h-screen bg-base px-6 pb-32 pt-12 text-text">
-			<div class="mx-auto max-w-3xl space-y-10">
-				<nav aria-label="Primary" class="flex flex-wrap gap-4 text-sm text-muted">
-					<a class="text-foam hover:text-text" href="/">Home</a>
-					<a class="text-foam hover:text-text" href="/quote/">Quote mode</a>
-					<a class="text-foam hover:text-text" href="/zen/">Zen mode</a>
-					<a class="text-foam hover:text-text" href="/about/">About</a>
-					<a class="text-foam hover:text-text" href="/privacy/">Privacy</a>
+		<main class="content-page px-6 pb-32 pt-16 text-text">
+			<div class="mx-auto max-w-3xl space-y-8">
+				<nav aria-label="Primary" class="content-nav">
+					<a href="/">Home</a>
+					<a href="/quote/">Quote mode</a>
+					<a href="/zen/">Zen mode</a>
+					<a href="/about/">About</a>
+					<a href="/privacy/">Privacy</a>
 				</nav>
 
-				<header class="space-y-4 border-b border-iris/15 pb-8">
-					<p class="text-sm font-medium uppercase tracking-[0.28em] text-iris">Contact</p>
-					<h1 class="text-4xl font-semibold tracking-tight text-text md:text-5xl">Contact Zen Typer</h1>
-					<p class="text-lg leading-8 text-muted">
-						Use the links below to reach Jonathan Reed about Zen Typer, report a problem, or share feedback about typing practice, accessibility, or privacy.
-					</p>
-				</header>
+				<article class="glass content-prose rounded-2xl p-8 md:p-10 space-y-8 stagger-fade-in">
+					<header class="space-y-4 border-b border-iris/15 pb-7">
+						<p class="eyebrow text-sm font-medium uppercase tracking-[0.28em]">Contact</p>
+						<h1>Contact Zen Typer</h1>
+						<p class="!text-lg !leading-8">
+							Use the links below to reach Jonathan Reed about Zen Typer, report a problem, or share feedback about typing practice, accessibility, or privacy.
+						</p>
+					</header>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">Feedback and support</h2>
-					<p>
-						The best feedback is specific. If a quote feels broken, a typing state is confusing, a control is hard to reach with a keyboard, or a screen reader label does not match the visible interface, include the page, browser, device, and what happened. Accessibility reports are especially useful because Zen Typer is meant to be calm and usable without relying on pointer-only controls.
-					</p>
-					<p>
-						You can reach Jonathan through the main website at <a class="text-foam hover:text-text" href="https://jonathanrreed.com" target="_blank" rel="noopener noreferrer">jonathanrreed.com</a> or through Bluesky at <a class="text-foam hover:text-text" href="https://bsky.app/profile/thereedy.bsky.social" target="_blank" rel="noopener noreferrer">@thereedy.bsky.social</a>. For project context and related work, visit <a class="text-foam hover:text-text" href="https://jonathanrreed.com/projects/" target="_blank" rel="noopener noreferrer">Jonathan Reed projects</a>.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>Feedback and support</h2>
+						<p>
+							The best feedback is specific. If a quote feels broken, a typing state is confusing, a control is hard to reach with a keyboard, or a screen reader label does not match the visible interface, include the page, browser, device, and what happened. Accessibility reports are especially useful because Zen Typer is meant to be calm and usable without relying on pointer-only controls.
+						</p>
+						<p>
+							You can reach Jonathan through the main website at <a href="https://jonathanrreed.com" target="_blank" rel="noopener noreferrer">jonathanrreed.com</a> or through Bluesky at <a href="https://bsky.app/profile/thereedy.bsky.social" target="_blank" rel="noopener noreferrer">@thereedy.bsky.social</a>. For project context and related work, visit <a href="https://jonathanrreed.com/projects/" target="_blank" rel="noopener noreferrer">Jonathan Reed projects</a>.
+						</p>
+					</section>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">What to include</h2>
-					<p>
-						For bug reports, include whether you were using Quote Mode or Zen Mode, whether reduced motion was enabled, and whether the issue affected typing input, stats, drafts, settings, navigation, or display. For content suggestions, include the quote, author, or topic you think would improve the typing practice library.
-					</p>
-					<p>
-						For accessibility reports, describe the control name, keyboard step, screen size, or assistive technology behavior that made the session harder to use. For privacy questions, note whether the concern involves local drafts, archived sessions, browser storage, external links, or hosting logs.
-					</p>
-					<p>
-						Zen Typer is intentionally small, so clear reports are more useful than broad feature requests. The goal is to keep the typing surface calm while fixing issues that block practice, navigation, reading, or trust.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>What to include</h2>
+						<p>
+							For bug reports, include whether you were using Quote Mode or Zen Mode, whether reduced motion was enabled, and whether the issue affected typing input, stats, drafts, settings, navigation, or display. For content suggestions, include the quote, author, or topic you think would improve the typing practice library.
+						</p>
+						<p>
+							For accessibility reports, describe the control name, keyboard step, screen size, or assistive technology behavior that made the session harder to use. For privacy questions, note whether the concern involves local drafts, archived sessions, browser storage, external links, or hosting logs.
+						</p>
+						<p>
+							Zen Typer is intentionally small, so clear reports are more useful than broad feature requests. The goal is to keep the typing surface calm while fixing issues that block practice, navigation, reading, or trust.
+						</p>
+					</section>
+				</article>
 			</div>
 		</main>
 	</body>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -26,46 +26,48 @@ const privacyUrl = `${siteUrl}/privacy/`;
 		/>
 	</head>
 	<body>
-		<main class="min-h-screen bg-base px-6 pb-32 pt-12 text-text">
-			<div class="mx-auto max-w-3xl space-y-10">
-				<nav aria-label="Primary" class="flex flex-wrap gap-4 text-sm text-muted">
-					<a class="text-foam hover:text-text" href="/">Home</a>
-					<a class="text-foam hover:text-text" href="/quote/">Quote mode</a>
-					<a class="text-foam hover:text-text" href="/zen/">Zen mode</a>
-					<a class="text-foam hover:text-text" href="/about/">About</a>
-					<a class="text-foam hover:text-text" href="/contact/">Contact</a>
+		<main class="content-page px-6 pb-32 pt-16 text-text">
+			<div class="mx-auto max-w-3xl space-y-8">
+				<nav aria-label="Primary" class="content-nav">
+					<a href="/">Home</a>
+					<a href="/quote/">Quote mode</a>
+					<a href="/zen/">Zen mode</a>
+					<a href="/about/">About</a>
+					<a href="/contact/">Contact</a>
 				</nav>
 
-				<header class="space-y-4 border-b border-iris/15 pb-8">
-					<p class="text-sm font-medium uppercase tracking-[0.28em] text-iris">Privacy</p>
-					<h1 class="text-4xl font-semibold tracking-tight text-text md:text-5xl">Zen Typer Privacy</h1>
-					<p class="text-lg leading-8 text-muted">
-						Zen Typer is designed as an account-free typing practice app. It keeps core writing and practice data in your browser.
-					</p>
-				</header>
+				<article class="glass content-prose rounded-2xl p-8 md:p-10 space-y-8 stagger-fade-in">
+					<header class="space-y-4 border-b border-iris/15 pb-7">
+						<p class="eyebrow text-sm font-medium uppercase tracking-[0.28em]">Privacy</p>
+						<h1>Zen Typer Privacy</h1>
+						<p class="!text-lg !leading-8">
+							Zen Typer is designed as an account-free typing practice app. It keeps core writing and practice data in your browser.
+						</p>
+					</header>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">What the app stores</h2>
-					<p>
-						Zen Typer may use browser storage for settings, local drafts, archived writing sessions, theme preferences, reduced-motion preferences, and typing practice metrics such as WPM, accuracy, streaks, and session progress. This storage lets the app remember your workspace without requiring an account. Clearing browser storage for this site can remove those saved preferences and drafts.
-					</p>
-					<p>
-						The app does not ask for a login, password, payment method, or profile. Typing practice can be used directly in the browser. Avoid entering sensitive personal, financial, medical, or confidential workplace information into any browser-based writing tool unless you are comfortable storing that content locally on your own device.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>What the app stores</h2>
+						<p>
+							Zen Typer may use browser storage for settings, local drafts, archived writing sessions, theme preferences, reduced-motion preferences, and typing practice metrics such as WPM, accuracy, streaks, and session progress. This storage lets the app remember your workspace without requiring an account. Clearing browser storage for this site can remove those saved preferences and drafts.
+						</p>
+						<p>
+							The app does not ask for a login, password, payment method, or profile. Typing practice can be used directly in the browser. Avoid entering sensitive personal, financial, medical, or confidential workplace information into any browser-based writing tool unless you are comfortable storing that content locally on your own device.
+						</p>
+					</section>
 
-				<section class="space-y-5 text-base leading-8 text-muted">
-					<h2 class="text-2xl font-semibold text-text">Analytics and third parties</h2>
-					<p>
-						Zen Typer is hosted on Cloudflare Pages. Cloudflare may process standard request metadata needed to serve the site, protect the service, and measure basic delivery health. The app is built to keep the typing experience local and lightweight. External links to Jonathan Reed projects or social profiles leave this site and are governed by those services.
-					</p>
-					<p>
-						Local storage is device and browser specific. A draft saved in one browser profile is not meant to follow you to another device, and clearing site data can remove saved settings or archives. This keeps the app simple, but it also means users should export or move any writing they want to keep long term.
-					</p>
-					<p>
-						Questions about privacy, accessibility, or data handling can be sent through the contact options on the <a class="text-foam hover:text-text" href="/contact/">contact page</a>. This notice was last updated on April 21, 2026.
-					</p>
-				</section>
+					<section class="space-y-4">
+						<h2>Analytics and third parties</h2>
+						<p>
+							Zen Typer is hosted on Cloudflare Pages. Cloudflare may process standard request metadata needed to serve the site, protect the service, and measure basic delivery health. The app is built to keep the typing experience local and lightweight. External links to Jonathan Reed projects or social profiles leave this site and are governed by those services.
+						</p>
+						<p>
+							Local storage is device and browser specific. A draft saved in one browser profile is not meant to follow you to another device, and clearing site data can remove saved settings or archives. This keeps the app simple, but it also means users should export or move any writing they want to keep long term.
+						</p>
+						<p>
+							Questions about privacy, accessibility, or data handling can be sent through the contact options on the <a href="/contact/">contact page</a>. This notice was last updated on April 21, 2026.
+						</p>
+					</section>
+				</article>
 			</div>
 		</main>
 	</body>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -433,8 +433,8 @@ html[data-motion="off"] .typing-cursor::after {
 .content-page {
   min-height: 100vh;
   background:
-    radial-gradient(ellipse 90% 55% at 50% -8%, color-mix(in oklab, var(--rp-iris) 15%, transparent) 0%, transparent 68%),
-    radial-gradient(ellipse 70% 50% at 82% 112%, color-mix(in oklab, var(--rp-foam) 9%, transparent) 0%, transparent 70%),
+    radial-gradient(ellipse 90% 55% at 50% -8%, color-mix(in oklab, var(--theme-accent) 15%, transparent) 0%, transparent 68%),
+    radial-gradient(ellipse 70% 50% at 82% 112%, color-mix(in oklab, var(--theme-accent-2) 9%, transparent) 0%, transparent 70%),
     linear-gradient(180deg, var(--rp-base) 0%, color-mix(in oklab, var(--rp-overlay) 65%, var(--rp-base) 35%) 100%);
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3008,142 +3008,157 @@ html.theme-glacier .glass {
   pointer-events: none;
 }
 
-@keyframes pfield-twinkle { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
-@keyframes pfield-glow    { 0%, 100% { opacity: 0.42; } 50% { opacity: 0.85; } }
+@keyframes pfield-twinkle { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
+@keyframes pfield-glow    { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
 @keyframes pfield-rise    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, -300px, 0); } }
 @keyframes pfield-fall    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, 300px, 0); } }
 @keyframes pfield-drift   { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(-300px, -300px, 0); } }
 
-/* Void — faint distant starfield (depth behind the aurora) */
+/* Void — distant starfield (depth behind the aurora) */
 html.theme-void .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1px at 15% 12%, color-mix(in oklab, var(--rp-iris) 70%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 38% 28%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 62% 18%, rgba(255, 255, 255, 0.55), transparent 60%),
-    radial-gradient(circle 0.8px at 82% 34%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 26% 52%, color-mix(in oklab, var(--rp-foam) 55%, transparent), transparent 60%),
-    radial-gradient(circle 0.9px at 54% 66%, rgba(255, 255, 255, 0.5), transparent 60%),
-    radial-gradient(circle 1px at 74% 58%, color-mix(in oklab, var(--rp-iris) 60%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 12% 78%, color-mix(in oklab, var(--rp-foam) 50%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 44% 88%, rgba(255, 255, 255, 0.5), transparent 60%),
-    radial-gradient(circle 0.9px at 88% 82%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%);
-  opacity: 0.5;
-  animation: pfield-drift 220s linear infinite, pfield-twinkle 8s ease-in-out infinite;
+    radial-gradient(circle 1.8px at 15% 12%, color-mix(in oklab, var(--rp-iris) 95%, transparent), transparent 62%),
+    radial-gradient(circle 1.4px at 38% 28%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 62% 18%, rgba(255, 255, 255, 0.95), transparent 62%),
+    radial-gradient(circle 1.4px at 82% 34%, color-mix(in oklab, var(--rp-iris) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 26% 52%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 54% 66%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.8px at 74% 58%, color-mix(in oklab, var(--rp-iris) 90%, transparent), transparent 62%),
+    radial-gradient(circle 1.4px at 12% 78%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 44% 88%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.5px at 88% 82%, color-mix(in oklab, var(--rp-iris) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 30% 38%, color-mix(in oklab, var(--rp-foam) 75%, transparent), transparent 62%),
+    radial-gradient(circle 1.6px at 68% 40%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.3px at 6% 46%, color-mix(in oklab, var(--rp-iris) 80%, transparent), transparent 62%);
+  opacity: 0.92;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-iris) 45%, transparent));
+  animation: pfield-drift 200s linear infinite, pfield-twinkle 7s ease-in-out infinite;
 }
 
 /* Forest — fireflies (near) + pollen (far) */
 html.theme-forest .theme-layer > .ocean-lights > .stars-near {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1.6px at 18% 24%, color-mix(in oklab, var(--rp-gold) 85%, transparent), transparent 55%),
-    radial-gradient(circle 1.3px at 46% 16%, #8fd0a8, transparent 55%),
-    radial-gradient(circle 1.8px at 72% 30%, color-mix(in oklab, var(--rp-gold) 80%, transparent), transparent 55%),
-    radial-gradient(circle 1.4px at 30% 54%, color-mix(in oklab, var(--rp-foam) 70%, transparent), transparent 55%),
-    radial-gradient(circle 1.6px at 64% 62%, color-mix(in oklab, var(--rp-gold) 82%, transparent), transparent 55%),
-    radial-gradient(circle 1.3px at 86% 70%, #8fd0a8, transparent 55%),
-    radial-gradient(circle 1.5px at 12% 82%, color-mix(in oklab, var(--rp-gold) 78%, transparent), transparent 55%);
-  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-gold) 50%, transparent));
-  opacity: 0.7;
-  animation: pfield-drift 140s ease-in-out infinite alternate, pfield-glow 4.5s ease-in-out infinite;
+    radial-gradient(circle 2.8px at 18% 24%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 58%),
+    radial-gradient(circle 2.4px at 46% 16%, #a8e6c0, transparent 58%),
+    radial-gradient(circle 3px at 72% 30%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 58%),
+    radial-gradient(circle 2.4px at 30% 54%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 58%),
+    radial-gradient(circle 2.8px at 64% 62%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 58%),
+    radial-gradient(circle 2.4px at 86% 70%, #a8e6c0, transparent 58%),
+    radial-gradient(circle 2.6px at 12% 82%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 58%),
+    radial-gradient(circle 2.3px at 40% 88%, color-mix(in oklab, var(--rp-gold) 85%, transparent), transparent 58%);
+  filter: drop-shadow(0 0 6px color-mix(in oklab, var(--rp-gold) 70%, transparent));
+  opacity: 0.95;
+  animation: pfield-drift 140s ease-in-out infinite alternate, pfield-glow 4s ease-in-out infinite;
 }
 html.theme-forest .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 0.9px at 22% 18%, color-mix(in oklab, var(--rp-gold) 50%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 54% 32%, #a3d9b1, transparent 60%),
-    radial-gradient(circle 1px at 78% 22%, color-mix(in oklab, var(--rp-gold) 45%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 34% 60%, #a3d9b1, transparent 60%),
-    radial-gradient(circle 0.9px at 66% 74%, color-mix(in oklab, var(--rp-gold) 48%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 14% 88%, #a3d9b1, transparent 60%);
-  opacity: 0.32;
-  animation: pfield-rise 120s linear infinite;
+    radial-gradient(circle 1.4px at 22% 18%, color-mix(in oklab, var(--rp-gold) 80%, transparent), transparent 60%),
+    radial-gradient(circle 1.3px at 54% 32%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.5px at 78% 22%, color-mix(in oklab, var(--rp-gold) 75%, transparent), transparent 60%),
+    radial-gradient(circle 1.3px at 34% 60%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.4px at 66% 74%, color-mix(in oklab, var(--rp-gold) 78%, transparent), transparent 60%),
+    radial-gradient(circle 1.3px at 14% 88%, #a3d9b1, transparent 60%);
+  opacity: 0.6;
+  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-gold) 45%, transparent));
+  animation: pfield-rise 120s linear infinite, pfield-twinkle 9s ease-in-out infinite;
 }
 
 /* Ocean — rising bubbles (near) + plankton (far) */
 html.theme-ocean .theme-layer > .ocean-lights > .stars-near {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 2.5px at 20% 80%, transparent 36%, color-mix(in oklab, var(--seafoam) 55%, transparent) 48%, transparent 62%),
-    radial-gradient(circle 2px at 48% 90%, transparent 36%, color-mix(in oklab, var(--rp-foam) 50%, transparent) 48%, transparent 62%),
-    radial-gradient(circle 3px at 72% 84%, transparent 36%, color-mix(in oklab, var(--seafoam) 50%, transparent) 48%, transparent 62%),
-    radial-gradient(circle 2px at 86% 76%, transparent 36%, color-mix(in oklab, var(--rp-foam) 48%, transparent) 48%, transparent 62%),
-    radial-gradient(circle 2.2px at 34% 70%, transparent 36%, color-mix(in oklab, var(--seafoam) 48%, transparent) 48%, transparent 62%);
-  opacity: 0.55;
+    radial-gradient(circle 4px at 20% 80%, transparent 40%, color-mix(in oklab, var(--seafoam) 85%, transparent) 52%, transparent 66%),
+    radial-gradient(circle 3px at 48% 90%, transparent 40%, color-mix(in oklab, var(--rp-foam) 80%, transparent) 52%, transparent 66%),
+    radial-gradient(circle 5px at 72% 84%, transparent 42%, color-mix(in oklab, var(--seafoam) 80%, transparent) 52%, transparent 66%),
+    radial-gradient(circle 3px at 86% 76%, transparent 40%, color-mix(in oklab, var(--rp-foam) 78%, transparent) 52%, transparent 66%),
+    radial-gradient(circle 3.5px at 34% 70%, transparent 40%, color-mix(in oklab, var(--seafoam) 78%, transparent) 52%, transparent 66%),
+    radial-gradient(circle 2.6px at 58% 66%, transparent 40%, color-mix(in oklab, var(--rp-foam) 72%, transparent) 52%, transparent 66%);
+  opacity: 0.85;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--seafoam) 50%, transparent));
   animation: pfield-rise 26s linear infinite, pfield-twinkle 7s ease-in-out infinite;
 }
 html.theme-ocean .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1px at 18% 30%, color-mix(in oklab, var(--seafoam) 55%, transparent), transparent 60%),
-    radial-gradient(circle 0.8px at 52% 20%, color-mix(in oklab, var(--rp-foam) 50%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 76% 40%, color-mix(in oklab, var(--seafoam) 50%, transparent), transparent 60%),
-    radial-gradient(circle 0.9px at 38% 64%, color-mix(in oklab, var(--rp-foam) 48%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 64% 78%, color-mix(in oklab, var(--seafoam) 52%, transparent), transparent 60%);
-  opacity: 0.3;
-  animation: pfield-rise 46s linear infinite;
+    radial-gradient(circle 1.5px at 18% 30%, color-mix(in oklab, var(--seafoam) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 52% 20%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 76% 40%, color-mix(in oklab, var(--seafoam) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 38% 64%, color-mix(in oklab, var(--rp-foam) 78%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 64% 78%, color-mix(in oklab, var(--seafoam) 82%, transparent), transparent 62%);
+  opacity: 0.6;
+  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-foam) 45%, transparent));
+  animation: pfield-rise 46s linear infinite, pfield-twinkle 8s ease-in-out infinite;
 }
 
-/* Aurora — fine snow / star dust */
+/* Aurora — snow / star dust */
 html.theme-aurora .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1px at 16% 14%, rgba(255, 255, 255, 0.7), transparent 60%),
-    radial-gradient(circle 0.8px at 40% 26%, color-mix(in oklab, var(--rp-foam) 65%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 66% 16%, rgba(255, 255, 255, 0.6), transparent 60%),
-    radial-gradient(circle 0.8px at 84% 32%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 28% 50%, rgba(255, 255, 255, 0.6), transparent 60%),
-    radial-gradient(circle 0.9px at 56% 64%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 78% 60%, rgba(255, 255, 255, 0.55), transparent 60%),
-    radial-gradient(circle 0.8px at 14% 80%, color-mix(in oklab, var(--rp-iris) 50%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 46% 90%, rgba(255, 255, 255, 0.55), transparent 60%);
-  opacity: 0.5;
-  animation: pfield-fall 80s linear infinite, pfield-twinkle 6.5s ease-in-out infinite;
+    radial-gradient(circle 1.8px at 16% 14%, rgba(255, 255, 255, 0.95), transparent 62%),
+    radial-gradient(circle 1.4px at 40% 26%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 66% 16%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.4px at 84% 32%, color-mix(in oklab, var(--rp-iris) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 28% 50%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.5px at 56% 64%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 78% 60%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.4px at 14% 80%, color-mix(in oklab, var(--rp-iris) 75%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 46% 90%, rgba(255, 255, 255, 0.85), transparent 62%);
+  opacity: 0.9;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-foam) 50%, transparent));
+  animation: pfield-fall 70s linear infinite, pfield-twinkle 6.5s ease-in-out infinite;
 }
 
-/* Ember — distant rising sparks */
+/* Ember — rising sparks */
 html.theme-ember .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1.1px at 20% 86%, color-mix(in oklab, var(--rp-gold) 75%, transparent), transparent 60%),
-    radial-gradient(circle 0.9px at 44% 92%, color-mix(in oklab, var(--rp-love) 65%, transparent), transparent 60%),
-    radial-gradient(circle 1.2px at 66% 88%, color-mix(in oklab, var(--rp-gold) 70%, transparent), transparent 60%),
-    radial-gradient(circle 0.9px at 82% 80%, color-mix(in oklab, var(--rp-rose) 60%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 32% 72%, color-mix(in oklab, var(--rp-gold) 68%, transparent), transparent 60%),
-    radial-gradient(circle 0.9px at 74% 66%, color-mix(in oklab, var(--rp-love) 58%, transparent), transparent 60%);
-  opacity: 0.42;
-  animation: pfield-rise 38s linear infinite, pfield-twinkle 4s ease-in-out infinite;
+    radial-gradient(circle 1.8px at 20% 86%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 44% 92%, color-mix(in oklab, var(--rp-love) 85%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 66% 88%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 82% 80%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 32% 72%, color-mix(in oklab, var(--rp-gold) 88%, transparent), transparent 62%),
+    radial-gradient(circle 1.5px at 74% 66%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.6px at 14% 60%, color-mix(in oklab, var(--rp-gold) 82%, transparent), transparent 62%);
+  opacity: 0.85;
+  filter: drop-shadow(0 0 5px color-mix(in oklab, var(--rp-gold) 60%, transparent));
+  animation: pfield-rise 36s linear infinite, pfield-twinkle 4s ease-in-out infinite;
 }
 
-/* Sakura — distant drifting blossom motes */
+/* Sakura — drifting blossom motes */
 html.theme-sakura .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1.2px at 18% 14%, color-mix(in oklab, var(--rp-rose) 70%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 44% 24%, color-mix(in oklab, var(--rp-love) 60%, transparent), transparent 60%),
-    radial-gradient(circle 1.3px at 70% 16%, color-mix(in oklab, var(--rp-rose) 65%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 30% 52%, color-mix(in oklab, var(--rp-iris) 50%, transparent), transparent 60%),
-    radial-gradient(circle 1.2px at 62% 60%, color-mix(in oklab, var(--rp-rose) 62%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 84% 70%, color-mix(in oklab, var(--rp-love) 55%, transparent), transparent 60%);
-  opacity: 0.4;
-  animation: pfield-fall 70s linear infinite, pfield-twinkle 7.5s ease-in-out infinite;
+    radial-gradient(circle 2.2px at 18% 14%, color-mix(in oklab, var(--rp-rose) 92%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 44% 24%, color-mix(in oklab, var(--rp-love) 82%, transparent), transparent 62%),
+    radial-gradient(circle 2.4px at 70% 16%, color-mix(in oklab, var(--rp-rose) 88%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 30% 52%, color-mix(in oklab, var(--rp-iris) 72%, transparent), transparent 62%),
+    radial-gradient(circle 2.2px at 62% 60%, color-mix(in oklab, var(--rp-rose) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 84% 70%, color-mix(in oklab, var(--rp-love) 78%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 10% 84%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 62%);
+  opacity: 0.85;
+  filter: drop-shadow(0 0 5px color-mix(in oklab, var(--rp-rose) 55%, transparent));
+  animation: pfield-fall 64s linear infinite, pfield-twinkle 7.5s ease-in-out infinite;
 }
 
-/* Glacier — fine drifting snow */
+/* Glacier — drifting snow */
 html.theme-glacier .theme-layer > .ocean-lights > .stars-far {
   background-size: 300px 300px;
   background-image:
-    radial-gradient(circle 1px at 14% 16%, rgba(255, 255, 255, 0.75), transparent 60%),
-    radial-gradient(circle 0.8px at 40% 24%, color-mix(in oklab, var(--rp-foam) 70%, transparent), transparent 60%),
-    radial-gradient(circle 1.1px at 64% 14%, rgba(255, 255, 255, 0.7), transparent 60%),
-    radial-gradient(circle 0.8px at 84% 30%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 26% 50%, rgba(255, 255, 255, 0.65), transparent 60%),
-    radial-gradient(circle 0.9px at 54% 62%, color-mix(in oklab, var(--rp-foam) 62%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 78% 58%, rgba(255, 255, 255, 0.6), transparent 60%),
-    radial-gradient(circle 0.8px at 16% 80%, color-mix(in oklab, var(--rp-foam) 58%, transparent), transparent 60%),
-    radial-gradient(circle 1px at 48% 90%, rgba(255, 255, 255, 0.6), transparent 60%);
-  opacity: 0.55;
-  animation: pfield-fall 75s linear infinite, pfield-twinkle 6s ease-in-out infinite;
+    radial-gradient(circle 1.8px at 14% 16%, rgba(255, 255, 255, 0.95), transparent 62%),
+    radial-gradient(circle 1.4px at 40% 24%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 64% 14%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.4px at 84% 30%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 26% 50%, rgba(255, 255, 255, 0.88), transparent 62%),
+    radial-gradient(circle 1.5px at 54% 62%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 78% 58%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.4px at 16% 80%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 48% 90%, rgba(255, 255, 255, 0.85), transparent 62%);
+  opacity: 0.9;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-foam) 50%, transparent));
+  animation: pfield-fall 72s linear infinite, pfield-twinkle 6s ease-in-out infinite;
 }
 
 /* ---- Reduced motion: freeze all per-theme FX layers --------------------- */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -609,12 +609,6 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
   transform: translateY(-1px);
 }
 
-/* Zen caret animation */
-.zen-caret {
-  animation: zen-caret-pulse 1.2s ease-in-out infinite;
-  transform-origin: center;
-}
-
 /* Quote typing character system — clean, borderless, premium
    States are driven by class (pending / correct / error / current). No per-char
    borders: legibility comes from color + a single glowing caret. Words are kept
@@ -746,10 +740,6 @@ html[data-motion="off"] .quote-char.current {
   box-shadow:
     inset 0 -0.12em 0 0 var(--rp-iris),
     0 0 14px color-mix(in oklab, var(--rp-iris) 32%, transparent);
-}
-
-html[data-motion="off"] .zen-caret {
-  animation: blink 0.7s step-end infinite;
 }
 
 /* Vignette overlay to add depth on scenes */
@@ -2651,6 +2641,306 @@ html.theme-forest .theme-layer > .ocean-lights::before {
   50%       { opacity: 0.85; }
 }
 
+/* ==========================================================================
+   EMBER — warm hearth. Charcoal deepening to maroon, embers rising from a
+   low glow. The warm counterpoint to the cool themes.
+   ========================================================================== */
+html.theme-ember {
+  --ember-0: #080402;
+  --ember-1: #160a06;
+  --ember-3: #3d1810;
+  --theme-accent: var(--rp-gold);
+  --theme-accent-glow: color-mix(in oklab, var(--rp-gold) 20%, transparent);
+  --theme-border-glow: color-mix(in oklab, var(--rp-gold) 12%, transparent);
+  --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #2a120c 60%, var(--rp-love) 8%) 0%, #080402 100%);
+}
+
+html.theme-ember .theme-layer {
+  background:
+    radial-gradient(ellipse 140% 100% at 50% 50%, transparent 42%, rgba(0, 0, 0, 0.72) 100%),
+    radial-gradient(ellipse 90% 55% at 50% 112%, color-mix(in oklab, var(--rp-gold) 46%, transparent) 0%, color-mix(in oklab, var(--rp-love) 30%, transparent) 38%, transparent 78%),
+    radial-gradient(ellipse 60% 45% at 78% 80%, color-mix(in oklab, var(--rp-rose) 26%, transparent) 0%, transparent 76%),
+    radial-gradient(ellipse 55% 42% at 22% 76%, color-mix(in oklab, var(--rp-love) 22%, transparent) 0%, transparent 78%),
+    linear-gradient(170deg, color-mix(in oklab, var(--ember-3) 70%, var(--rp-love) 30%) 0%, var(--ember-1) 52%, var(--ember-0) 100%);
+}
+
+html.theme-ember .theme-layer > .ocean-lights::before {
+  content: "";
+  position: absolute;
+  inset: -10%;
+  background-image:
+    radial-gradient(circle 1.6px at 18% 90%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 60%),
+    radial-gradient(circle 1.2px at 32% 96%, color-mix(in oklab, var(--rp-love) 85%, transparent), transparent 60%),
+    radial-gradient(circle 2px at 48% 88%, color-mix(in oklab, var(--rp-gold) 88%, transparent), transparent 60%),
+    radial-gradient(circle 1.3px at 63% 94%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 60%),
+    radial-gradient(circle 1.7px at 76% 90%, color-mix(in oklab, var(--rp-gold) 86%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 88% 96%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 60%),
+    radial-gradient(circle 1.5px at 8% 84%, color-mix(in oklab, var(--rp-gold) 84%, transparent), transparent 60%),
+    radial-gradient(circle 1.2px at 55% 98%, color-mix(in oklab, var(--rp-rose) 80%, transparent), transparent 60%);
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0.45;
+  filter: blur(0.3px);
+  animation: ember-rise 14s linear infinite, ember-flicker 3.5s ease-in-out infinite;
+}
+
+html.theme-ember[data-motion="on"] .theme-layer > .ocean-lights::after {
+  content: "";
+  position: absolute;
+  inset: -10%;
+  background-image:
+    radial-gradient(circle 1px at 25% 80%, color-mix(in oklab, var(--rp-gold) 70%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 42% 86%, color-mix(in oklab, var(--rp-love) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1.2px at 68% 82%, color-mix(in oklab, var(--rp-gold) 68%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 84% 88%, color-mix(in oklab, var(--rp-rose) 64%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 14% 78%, color-mix(in oklab, var(--rp-gold) 66%, transparent), transparent 60%);
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0.5;
+  animation: ember-rise 22s linear infinite, ember-flicker 5s ease-in-out infinite 1s;
+}
+
+@keyframes ember-rise {
+  from { transform: translateY(10%); }
+  to   { transform: translateY(-100%); }
+}
+
+@keyframes ember-flicker {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 0.68; }
+}
+
+/* ==========================================================================
+   SAKURA — soft dusk-pink. Muted rose/iris bloom with petals drifting down.
+   ========================================================================== */
+html.theme-sakura {
+  --sak-0: #120b16;
+  --sak-1: #1d1322;
+  --sak-2: #2a1b30;
+  --sak-petal: color-mix(in oklab, var(--rp-rose) 70%, var(--rp-love) 30%);
+  --theme-accent: var(--rp-rose);
+  --theme-accent-glow: color-mix(in oklab, var(--rp-rose) 20%, transparent);
+  --theme-border-glow: color-mix(in oklab, var(--rp-rose) 12%, transparent);
+  --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #2a1b30 60%, var(--rp-rose) 12%) 0%, #120b16 100%);
+}
+
+html.theme-sakura .theme-layer {
+  background:
+    radial-gradient(ellipse 140% 100% at 50% 50%, transparent 46%, rgba(0, 0, 0, 0.58) 100%),
+    radial-gradient(ellipse 95% 55% at 50% -6%, color-mix(in oklab, var(--rp-rose) 34%, transparent) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 45% at 24% 26%, color-mix(in oklab, var(--rp-iris) 22%, transparent) 0%, transparent 78%),
+    radial-gradient(ellipse 60% 45% at 78% 34%, color-mix(in oklab, var(--rp-love) 22%, transparent) 0%, transparent 80%),
+    linear-gradient(168deg, color-mix(in oklab, var(--sak-2) 64%, var(--rp-rose) 26%) 0%, var(--sak-1) 52%, var(--sak-0) 100%);
+}
+
+html.theme-sakura .theme-layer > .ocean-lights::before {
+  content: "";
+  position: absolute;
+  inset: -12%;
+  background-image:
+    radial-gradient(ellipse 3px 2px at 16% 6%, color-mix(in oklab, var(--sak-petal) 90%, transparent), transparent 65%),
+    radial-gradient(ellipse 2px 1.4px at 34% 2%, color-mix(in oklab, var(--rp-love) 84%, transparent), transparent 65%),
+    radial-gradient(ellipse 3px 2px at 52% 9%, color-mix(in oklab, var(--sak-petal) 86%, transparent), transparent 65%),
+    radial-gradient(ellipse 2.4px 1.6px at 68% 4%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 65%),
+    radial-gradient(ellipse 3px 2px at 82% 8%, color-mix(in oklab, var(--sak-petal) 88%, transparent), transparent 65%),
+    radial-gradient(ellipse 2px 1.4px at 92% 3%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 65%),
+    radial-gradient(ellipse 2.6px 1.8px at 8% 12%, color-mix(in oklab, var(--rp-rose) 80%, transparent), transparent 65%);
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0.55;
+  filter: blur(0.3px);
+  animation: sakura-fall 16s linear infinite, petal-sway 7s ease-in-out infinite;
+}
+
+html.theme-sakura[data-motion="on"] .theme-layer > .ocean-lights::after {
+  content: "";
+  position: absolute;
+  inset: -12%;
+  background-image:
+    radial-gradient(ellipse 2px 1.4px at 24% 2%, color-mix(in oklab, var(--sak-petal) 60%, transparent), transparent 65%),
+    radial-gradient(ellipse 2px 1.4px at 46% 5%, color-mix(in oklab, var(--rp-love) 58%, transparent), transparent 65%),
+    radial-gradient(ellipse 2.4px 1.6px at 70% 3%, color-mix(in oklab, var(--sak-petal) 60%, transparent), transparent 65%),
+    radial-gradient(ellipse 2px 1.4px at 88% 6%, color-mix(in oklab, var(--rp-love) 56%, transparent), transparent 65%);
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0.5;
+  animation: sakura-fall 24s linear infinite, petal-sway 9s ease-in-out infinite reverse;
+}
+
+@keyframes sakura-fall {
+  from { transform: translateY(-14%); }
+  to   { transform: translateY(102%); }
+}
+
+@keyframes petal-sway {
+  0%, 100% { background-position: 0 0; }
+  50%      { background-position: 3% 0; }
+}
+
+/* ==========================================================================
+   AURORA — polar night. Deep navy-black with slow ribbons of foam-green and
+   iris borealis light sweeping overhead.
+   ========================================================================== */
+html.theme-aurora {
+  --aur-0: #01030a;
+  --aur-1: #050b18;
+  --aur-2: #0a1628;
+  --theme-accent: var(--rp-foam);
+  --theme-accent-glow: color-mix(in oklab, var(--rp-foam) 18%, transparent);
+  --theme-border-glow: color-mix(in oklab, var(--rp-iris) 10%, transparent);
+  --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #0a1628 70%, var(--rp-pine) 14%) 0%, #01030a 100%);
+}
+
+html.theme-aurora .theme-layer {
+  background:
+    radial-gradient(ellipse 140% 100% at 50% 50%, transparent 40%, rgba(0, 0, 0, 0.74) 100%),
+    radial-gradient(ellipse 120% 50% at 50% 8%, color-mix(in oklab, var(--rp-foam) 14%, transparent) 0%, transparent 60%),
+    radial-gradient(ellipse 90% 60% at 50% 0%, color-mix(in oklab, var(--rp-iris) 12%, transparent) 0%, transparent 70%),
+    linear-gradient(180deg, color-mix(in oklab, var(--aur-2) 80%, var(--rp-pine) 12%) 0%, var(--aur-1) 55%, var(--aur-0) 100%);
+}
+
+html.theme-aurora .theme-layer > .ocean-lights {
+  mix-blend-mode: screen;
+}
+
+html.theme-aurora .theme-layer > .ocean-lights::before {
+  content: "";
+  position: absolute;
+  inset: -25% -10%;
+  background:
+    linear-gradient(96deg, transparent 0%, transparent 22%,
+      color-mix(in oklab, var(--rp-foam) 30%, transparent) 36%,
+      color-mix(in oklab, var(--rp-pine) 26%, transparent) 46%,
+      color-mix(in oklab, var(--rp-iris) 28%, transparent) 56%,
+      transparent 72%, transparent 100%);
+  filter: blur(46px);
+  mix-blend-mode: screen;
+  transform-origin: 50% 0%;
+  opacity: 0.7;
+  animation: aurora-wave 60s ease-in-out infinite;
+}
+
+html.theme-aurora[data-motion="on"] .theme-layer > .ocean-lights::after {
+  content: "";
+  position: absolute;
+  inset: -20% -10% auto -10%;
+  height: 62%;
+  background:
+    linear-gradient(86deg, transparent 0%, transparent 34%,
+      color-mix(in oklab, var(--rp-foam) 22%, transparent) 48%,
+      color-mix(in oklab, var(--rp-iris) 24%, transparent) 58%,
+      transparent 74%, transparent 100%);
+  filter: blur(32px);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  animation: aurora-wave-2 84s ease-in-out infinite reverse;
+}
+
+@keyframes aurora-wave {
+  0%   { transform: translateX(-6%) skewX(-8deg) scaleY(1); }
+  50%  { transform: translateX(6%) skewX(6deg) scaleY(1.08); }
+  100% { transform: translateX(-6%) skewX(-8deg) scaleY(1); }
+}
+
+@keyframes aurora-wave-2 {
+  0%   { transform: translateX(5%) skewX(7deg); }
+  50%  { transform: translateX(-5%) skewX(-6deg); }
+  100% { transform: translateX(5%) skewX(7deg); }
+}
+
+/* ==========================================================================
+   GLACIER — icy daylight. Pale frosted blues with a slow frost sheen and
+   drifting ice motes. The brightest, highest-contrast theme.
+   ========================================================================== */
+html.theme-glacier {
+  --gla-0: #08141e;
+  --gla-1: #0e2230;
+  --gla-3: #1f4a5c;
+  --ice: color-mix(in oklab, var(--rp-foam) 70%, #ffffff 30%);
+  --theme-accent: var(--rp-foam);
+  --theme-accent-glow: color-mix(in oklab, var(--rp-foam) 22%, transparent);
+  --theme-border-glow: color-mix(in oklab, var(--rp-foam) 14%, transparent);
+  --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #1f4a5c 65%, #ffffff 6%) 0%, #08141e 100%);
+}
+
+html.theme-glacier .theme-layer {
+  background:
+    radial-gradient(ellipse 140% 100% at 50% 50%, transparent 50%, rgba(0, 8, 16, 0.5) 100%),
+    radial-gradient(ellipse 110% 60% at 50% -10%, color-mix(in oklab, var(--ice) 40%, transparent) 0%, transparent 64%),
+    radial-gradient(ellipse 70% 50% at 26% 22%, color-mix(in oklab, var(--rp-foam) 24%, transparent) 0%, transparent 78%),
+    radial-gradient(ellipse 70% 50% at 76% 30%, color-mix(in oklab, #bfe6ef 22%, transparent) 0%, transparent 80%),
+    linear-gradient(176deg, color-mix(in oklab, var(--gla-3) 76%, #ffffff 8%) 0%, var(--gla-1) 56%, var(--gla-0) 100%);
+}
+
+html.theme-glacier .theme-layer > .ocean-lights::before {
+  content: "";
+  position: absolute;
+  inset: -25%;
+  background:
+    linear-gradient(115deg, transparent 0%, transparent 38%,
+      color-mix(in oklab, var(--ice) 32%, transparent) 48%,
+      color-mix(in oklab, #ffffff 26%, transparent) 52%,
+      transparent 62%, transparent 100%);
+  filter: blur(34px);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  animation: glacier-sheen 26s ease-in-out infinite alternate;
+}
+
+html.theme-glacier[data-motion="on"] .theme-layer > .ocean-lights::after {
+  content: "";
+  position: absolute;
+  inset: -8%;
+  background-image:
+    radial-gradient(circle 1.4px at 16% 22%, color-mix(in oklab, var(--ice) 92%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 34% 58%, rgba(255, 255, 255, 0.8), transparent 60%),
+    radial-gradient(circle 1.6px at 52% 30%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 68% 66%, rgba(255, 255, 255, 0.75), transparent 60%),
+    radial-gradient(circle 1.5px at 82% 40%, color-mix(in oklab, var(--ice) 88%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 90% 74%, rgba(255, 255, 255, 0.7), transparent 60%),
+    radial-gradient(circle 1.2px at 8% 70%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 60%);
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+  opacity: 0.7;
+  filter: blur(0.2px);
+  animation: ice-drift 30s ease-in-out infinite alternate, glacier-twinkle 5s ease-in-out infinite;
+}
+
+@keyframes glacier-sheen {
+  0%   { transform: translateX(-30%); }
+  100% { transform: translateX(30%); }
+}
+
+@keyframes ice-drift {
+  0%   { transform: translate3d(0, 0, 0); }
+  100% { transform: translate3d(2%, -2%, 0); }
+}
+
+@keyframes glacier-twinkle {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 0.85; }
+}
+
+/* New-theme glass glow tints (uses each theme's --theme-accent) */
+html.theme-ember .glass,
+html.theme-sakura .glass,
+html.theme-aurora .glass,
+html.theme-glacier .glass {
+  box-shadow:
+    var(--shadow-soft),
+    0 0 0 1px color-mix(in oklab, var(--theme-accent) 9%, transparent),
+    0 20px 60px -20px color-mix(in oklab, var(--theme-accent) 16%, transparent);
+}
+
+/* Mobile: drop the most expensive new-theme layers (big-blur ribbon/sheen) */
+@media (max-width: 640px) {
+  html.theme-aurora .theme-layer > .ocean-lights::before,
+  html.theme-aurora .theme-layer > .ocean-lights::after,
+  html.theme-glacier .theme-layer > .ocean-lights::before {
+    display: none;
+  }
+}
+
 /* ---- Reduced motion: freeze all per-theme FX layers --------------------- */
 html[data-motion="off"] .theme-layer > .ocean-lights,
 html[data-motion="off"] .theme-layer > .ocean-lights::before,
@@ -2757,20 +3047,6 @@ html.theme-ocean .glass {
       0 0 0 24px rgba(196, 167, 231, 0),
       0 4px 12px rgba(0, 0, 0, 0.3),
       inset 0 0 0 1px rgba(196, 167, 231, 0.2);
-  }
-}
-
-@keyframes zen-caret-pulse {
-
-  0%,
-  100% {
-    opacity: 1;
-    transform: scaleY(1);
-  }
-
-  50% {
-    opacity: 0.7;
-    transform: scaleY(0.95);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -489,25 +489,112 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
   transform-origin: center;
 }
 
-/* Quote typing character animations */
+/* Quote typing character system — clean, borderless, premium
+   States are driven by class (pending / correct / error / current). No per-char
+   borders: legibility comes from color + a single glowing caret. Words are kept
+   whole via .quote-word so the surface never wraps mid-word. */
+.quote-line {
+  position: relative;
+  margin-bottom: 0.3rem;
+}
+
+.quote-line:last-child {
+  margin-bottom: 0;
+}
+
+.quote-word {
+  display: inline-block;
+  white-space: nowrap;
+}
+
 .quote-char {
   display: inline-block;
-  animation: zen-char-appear 0.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  padding: 0.04em 0.045em;
+  border-radius: 5px;
+  /* pending = dim, readable but clearly "ahead of you" */
+  color: color-mix(in oklab, var(--rp-text) 34%, transparent);
+  transition:
+    color 0.18s var(--ease-smooth),
+    background-color 0.18s var(--ease-smooth),
+    text-shadow 0.18s var(--ease-smooth);
 }
 
 .quote-char.correct {
   color: var(--rp-foam);
+  text-shadow: 0 0 10px color-mix(in oklab, var(--rp-foam) 20%, transparent);
+  animation: quote-char-pop 0.18s var(--ease-smooth);
 }
 
 .quote-char.error {
   color: var(--rp-love);
-  animation: zen-char-appear 0.15s cubic-bezier(0.4, 0, 0.2, 1) forwards,
-    zen-glow-pulse 0.3s ease-in-out;
+  background: color-mix(in oklab, var(--rp-love) 14%, transparent);
+  text-decoration: underline wavy color-mix(in oklab, var(--rp-love) 65%, transparent);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1.5px;
+  animation: quote-char-shake 0.2s var(--ease-smooth);
 }
 
-.quote-char.pending {
-  opacity: 0.35;
-  transition: opacity 0.2s ease;
+.quote-char.current {
+  color: var(--rp-text);
+  background: color-mix(in oklab, var(--rp-iris) 20%, transparent);
+  box-shadow:
+    inset 0 -0.12em 0 0 color-mix(in oklab, var(--rp-iris) 85%, transparent),
+    0 0 16px color-mix(in oklab, var(--rp-iris) 28%, transparent);
+  animation: quote-caret-breathe 1.1s var(--ease-smooth) infinite;
+}
+
+@keyframes quote-char-pop {
+  0% { transform: translateY(1px) scale(0.96); }
+  60% { transform: translateY(0) scale(1.06); }
+  100% { transform: translateY(0) scale(1); }
+}
+
+@keyframes quote-char-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  75% { transform: translateX(2px); }
+}
+
+@keyframes quote-caret-breathe {
+  0%, 100% {
+    box-shadow:
+      inset 0 -0.12em 0 0 color-mix(in oklab, var(--rp-iris) 85%, transparent),
+      0 0 16px color-mix(in oklab, var(--rp-iris) 26%, transparent);
+  }
+  50% {
+    box-shadow:
+      inset 0 -0.12em 0 0 var(--rp-iris),
+      0 0 22px color-mix(in oklab, var(--rp-iris) 44%, transparent);
+  }
+}
+
+/* Single, elegant progress indicator beneath the quote */
+.quote-progress-track {
+  height: 3px;
+  width: 100%;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--rp-iris) 10%, transparent);
+  overflow: hidden;
+}
+
+.quote-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg,
+      color-mix(in oklab, var(--rp-foam) 85%, transparent),
+      color-mix(in oklab, var(--rp-iris) 85%, transparent));
+  box-shadow: 0 0 12px color-mix(in oklab, var(--rp-foam) 35%, transparent);
+  transition: width 0.25s var(--ease-smooth);
+}
+
+/* Gentle reveal when a fresh quote mounts */
+.quote-body {
+  animation: quote-body-in 0.45s var(--ease-smooth) both;
+}
+
+@keyframes quote-body-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* Reduce motion preferences */
@@ -520,8 +607,19 @@ html[data-motion="off"] .zen-input:focus {
   animation: none !important;
 }
 
-html[data-motion="off"] .quote-char {
+html[data-motion="off"] .quote-char,
+html[data-motion="off"] .quote-char.correct,
+html[data-motion="off"] .quote-char.error,
+html[data-motion="off"] .quote-char.current,
+html[data-motion="off"] .quote-body {
   animation: none !important;
+}
+
+/* Static caret for reduced motion: keep the underline + halo, no breathing */
+html[data-motion="off"] .quote-char.current {
+  box-shadow:
+    inset 0 -0.12em 0 0 var(--rp-iris),
+    0 0 14px color-mix(in oklab, var(--rp-iris) 32%, transparent);
 }
 
 html[data-motion="off"] .zen-caret {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,6 +54,7 @@
 
   /* Premium theme accent colors - subtle glows for each theme */
   --theme-accent: var(--rp-iris);
+  --theme-accent-2: var(--rp-foam);
   --theme-accent-glow: color-mix(in oklab, var(--rp-iris) 15%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--rp-iris) 8%, transparent);
 }
@@ -97,7 +98,7 @@ h4 {
   background: color-mix(in oklab, var(--rp-surface) 80%, transparent);
   backdrop-filter: blur(var(--blur));
   box-shadow: var(--shadow-soft);
-  border: 1px solid color-mix(in oklab, var(--rp-iris) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--theme-accent) 13%, transparent);
   position: relative;
 }
 
@@ -450,7 +451,7 @@ html[data-motion="off"] .typing-cursor::after {
   border-radius: 999px;
   font-size: 0.875rem;
   color: var(--rp-subtle);
-  border: 1px solid color-mix(in oklab, var(--rp-iris) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--theme-accent) 16%, transparent);
   background: color-mix(in oklab, var(--rp-overlay) 45%, transparent);
   transition:
     color 0.2s var(--ease-smooth),
@@ -461,8 +462,8 @@ html[data-motion="off"] .typing-cursor::after {
 
 .content-nav a:hover {
   color: var(--rp-text);
-  background: color-mix(in oklab, var(--rp-iris) 16%, transparent);
-  border-color: color-mix(in oklab, var(--rp-iris) 32%, transparent);
+  background: color-mix(in oklab, var(--theme-accent) 16%, transparent);
+  border-color: color-mix(in oklab, var(--theme-accent) 34%, transparent);
   transform: translateY(-1px);
 }
 
@@ -480,8 +481,8 @@ html[data-motion="off"] .typing-cursor::after {
 }
 
 .content-prose .eyebrow {
-  color: var(--rp-iris);
-  text-shadow: 0 0 18px color-mix(in oklab, var(--rp-iris) 30%, transparent);
+  color: var(--theme-accent);
+  text-shadow: 0 0 18px color-mix(in oklab, var(--theme-accent) 32%, transparent);
 }
 
 .content-prose h2 {
@@ -501,7 +502,7 @@ html[data-motion="off"] .typing-cursor::after {
   bottom: 0.18em;
   width: 3px;
   border-radius: 999px;
-  background: linear-gradient(180deg, var(--rp-iris), var(--rp-foam));
+  background: linear-gradient(180deg, var(--theme-accent), var(--theme-accent-2));
 }
 
 .content-prose p {
@@ -510,16 +511,16 @@ html[data-motion="off"] .typing-cursor::after {
 }
 
 .content-prose a {
-  color: var(--rp-foam);
+  color: var(--theme-accent-2);
   text-decoration: underline;
-  text-decoration-color: color-mix(in oklab, var(--rp-foam) 35%, transparent);
+  text-decoration-color: color-mix(in oklab, var(--theme-accent-2) 38%, transparent);
   text-underline-offset: 0.18em;
   transition: color 0.2s var(--ease-smooth), text-decoration-color 0.2s var(--ease-smooth);
 }
 
 .content-prose a:hover {
   color: var(--rp-text);
-  text-decoration-color: color-mix(in oklab, var(--rp-foam) 70%, transparent);
+  text-decoration-color: color-mix(in oklab, var(--theme-accent-2) 72%, transparent);
 }
 
 /* ==========================================================================
@@ -640,8 +641,10 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
 }
 
 .quote-char.correct {
-  color: var(--rp-foam);
-  text-shadow: 0 0 10px color-mix(in oklab, var(--rp-foam) 20%, transparent);
+  /* Typed text adopts the theme accent (blended with text for readability) so
+     the typed portion never clashes with the active theme. */
+  color: color-mix(in oklab, var(--theme-accent) 70%, var(--rp-text) 30%);
+  text-shadow: 0 0 10px color-mix(in oklab, var(--theme-accent) 22%, transparent);
   animation: quote-char-pop 0.18s var(--ease-smooth);
 }
 
@@ -656,10 +659,10 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
 
 .quote-char.current {
   color: var(--rp-text);
-  background: color-mix(in oklab, var(--rp-iris) 20%, transparent);
+  background: color-mix(in oklab, var(--theme-accent) 22%, transparent);
   box-shadow:
-    inset 0 -0.12em 0 0 color-mix(in oklab, var(--rp-iris) 85%, transparent),
-    0 0 16px color-mix(in oklab, var(--rp-iris) 28%, transparent);
+    inset 0 -0.12em 0 0 color-mix(in oklab, var(--theme-accent) 85%, transparent),
+    0 0 16px color-mix(in oklab, var(--theme-accent) 30%, transparent);
   animation: quote-caret-breathe 1.1s var(--ease-smooth) infinite;
 }
 
@@ -678,13 +681,13 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
 @keyframes quote-caret-breathe {
   0%, 100% {
     box-shadow:
-      inset 0 -0.12em 0 0 color-mix(in oklab, var(--rp-iris) 85%, transparent),
-      0 0 16px color-mix(in oklab, var(--rp-iris) 26%, transparent);
+      inset 0 -0.12em 0 0 color-mix(in oklab, var(--theme-accent) 85%, transparent),
+      0 0 16px color-mix(in oklab, var(--theme-accent) 26%, transparent);
   }
   50% {
     box-shadow:
-      inset 0 -0.12em 0 0 var(--rp-iris),
-      0 0 22px color-mix(in oklab, var(--rp-iris) 44%, transparent);
+      inset 0 -0.12em 0 0 var(--theme-accent),
+      0 0 22px color-mix(in oklab, var(--theme-accent) 44%, transparent);
   }
 }
 
@@ -693,7 +696,7 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
   height: 3px;
   width: 100%;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--rp-iris) 10%, transparent);
+  background: color-mix(in oklab, var(--theme-accent) 10%, transparent);
   overflow: hidden;
 }
 
@@ -701,9 +704,9 @@ html:not([data-motion="off"]) .zen-input:focus:not([data-typing="true"]) {
   height: 100%;
   border-radius: 999px;
   background: linear-gradient(90deg,
-      color-mix(in oklab, var(--rp-foam) 85%, transparent),
-      color-mix(in oklab, var(--rp-iris) 85%, transparent));
-  box-shadow: 0 0 12px color-mix(in oklab, var(--rp-foam) 35%, transparent);
+      color-mix(in oklab, var(--theme-accent-2) 85%, transparent),
+      color-mix(in oklab, var(--theme-accent) 85%, transparent));
+  box-shadow: 0 0 12px color-mix(in oklab, var(--theme-accent) 38%, transparent);
   transition: width 0.25s var(--ease-smooth);
 }
 
@@ -738,8 +741,8 @@ html[data-motion="off"] .quote-body {
 /* Static caret for reduced motion: keep the underline + halo, no breathing */
 html[data-motion="off"] .quote-char.current {
   box-shadow:
-    inset 0 -0.12em 0 0 var(--rp-iris),
-    0 0 14px color-mix(in oklab, var(--rp-iris) 32%, transparent);
+    inset 0 -0.12em 0 0 var(--theme-accent),
+    0 0 14px color-mix(in oklab, var(--theme-accent) 32%, transparent);
 }
 
 /* Vignette overlay to add depth on scenes */
@@ -848,16 +851,16 @@ html[data-motion="off"] .quote-char.current {
 
 /* Focus-visible accessibility ring across interactive elements */
 :where(a, button, [role="button"], input, select, textarea, [tabindex]):focus-visible {
-  outline: 2px solid color-mix(in oklab, var(--rp-iris) 70%, transparent);
+  outline: 2px solid color-mix(in oklab, var(--theme-accent) 72%, transparent);
   outline-offset: 2px;
-  box-shadow: 0 0 0 6px color-mix(in oklab, var(--rp-iris) 18%, transparent);
+  box-shadow: 0 0 0 6px color-mix(in oklab, var(--theme-accent) 18%, transparent);
 }
 
 /* Cards: subtle hover animation and glow */
 .card {
   @apply rounded-2xl;
   background: color-mix(in oklab, var(--rp-surface) 80%, transparent);
-  border: 1px solid color-mix(in oklab, var(--rp-iris) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--theme-accent) 15%, transparent);
   backdrop-filter: blur(var(--blur));
   box-shadow: var(--shadow-soft);
   transition: transform .2s var(--ease-smooth), background .2s var(--ease-smooth), border-color .2s var(--ease-smooth), box-shadow .2s var(--ease-smooth);
@@ -866,7 +869,7 @@ html[data-motion="off"] .quote-char.current {
 .card:hover,
 .card:focus-visible {
   transform: translateY(-2px) scale(1.01);
-  border-color: color-mix(in oklab, var(--rp-iris) 26%, transparent);
+  border-color: color-mix(in oklab, var(--theme-accent) 28%, transparent);
   box-shadow: 0 10px 36px rgba(0, 0, 0, .4);
 }
 
@@ -1776,6 +1779,7 @@ html.theme-cosmic {
 
   /* Cosmic theme accent glows */
   --theme-accent: var(--nebula);
+  --theme-accent-2: var(--rp-gold);
   --theme-accent-glow: color-mix(in oklab, var(--stardust) 20%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--nebula) 12%, transparent);
 
@@ -2682,6 +2686,7 @@ html.theme-ember {
   --ember-1: #160a06;
   --ember-3: #3d1810;
   --theme-accent: var(--rp-gold);
+  --theme-accent-2: var(--rp-rose);
   --theme-accent-glow: color-mix(in oklab, var(--rp-gold) 20%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--rp-gold) 12%, transparent);
   --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #2a120c 60%, var(--rp-love) 8%) 0%, #080402 100%);
@@ -2751,6 +2756,7 @@ html.theme-sakura {
   --sak-2: #2a1b30;
   --sak-petal: color-mix(in oklab, var(--rp-rose) 70%, var(--rp-love) 30%);
   --theme-accent: var(--rp-rose);
+  --theme-accent-2: var(--rp-iris);
   --theme-accent-glow: color-mix(in oklab, var(--rp-rose) 20%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--rp-rose) 12%, transparent);
   --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #2a1b30 60%, var(--rp-rose) 12%) 0%, #120b16 100%);
@@ -2818,6 +2824,7 @@ html.theme-aurora {
   --aur-1: #050b18;
   --aur-2: #0a1628;
   --theme-accent: var(--rp-foam);
+  --theme-accent-2: var(--rp-iris);
   --theme-accent-glow: color-mix(in oklab, var(--rp-foam) 18%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--rp-iris) 10%, transparent);
   --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #0a1628 70%, var(--rp-pine) 14%) 0%, #01030a 100%);
@@ -2890,6 +2897,7 @@ html.theme-glacier {
   --gla-3: #1f4a5c;
   --ice: color-mix(in oklab, var(--rp-foam) 70%, #ffffff 30%);
   --theme-accent: var(--rp-foam);
+  --theme-accent-2: var(--rp-iris);
   --theme-accent-glow: color-mix(in oklab, var(--rp-foam) 22%, transparent);
   --theme-border-glow: color-mix(in oklab, var(--rp-foam) 14%, transparent);
   --theme-gradient: linear-gradient(180deg, color-mix(in oklab, #1f4a5c 65%, #ffffff 6%) 0%, #08141e 100%);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3008,157 +3008,273 @@ html.theme-glacier .glass {
   pointer-events: none;
 }
 
-@keyframes pfield-twinkle { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
-@keyframes pfield-glow    { 0%, 100% { opacity: 0.6; } 50% { opacity: 1; } }
-@keyframes pfield-rise    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, -300px, 0); } }
-@keyframes pfield-fall    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, 300px, 0); } }
-@keyframes pfield-drift   { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(-300px, -300px, 0); } }
+@keyframes pf-twinkle { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+@keyframes pf-glow    { 0%, 100% { opacity: 0.45; } 50% { opacity: 0.95; } }
+@keyframes pf-rise    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, -360px, 0); } }
+@keyframes pf-fall    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, 360px, 0); } }
+@keyframes pf-drift   { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(-360px, -360px, 0); } }
 
-/* Void — distant starfield (depth behind the aurora) */
-html.theme-void .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+/* Every field below tiles at 360px and translates by exactly one tile, so it
+   loops seamlessly; dots are scattered across the WHOLE tile (the motif comes
+   from the drift DIRECTION, not from clustering) so there are no empty bands.
+   near = bigger/brighter/faster, far = smaller/dimmer/slower → parallax depth. */
+
+/* ---- Void: deep-field starfield ---- */
+html.theme-void .theme-layer > .ocean-lights > .stars-near {
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.8px at 15% 12%, color-mix(in oklab, var(--rp-iris) 95%, transparent), transparent 62%),
-    radial-gradient(circle 1.4px at 38% 28%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
-    radial-gradient(circle 2px at 62% 18%, rgba(255, 255, 255, 0.95), transparent 62%),
-    radial-gradient(circle 1.4px at 82% 34%, color-mix(in oklab, var(--rp-iris) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 26% 52%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 54% 66%, rgba(255, 255, 255, 0.9), transparent 62%),
-    radial-gradient(circle 1.8px at 74% 58%, color-mix(in oklab, var(--rp-iris) 90%, transparent), transparent 62%),
-    radial-gradient(circle 1.4px at 12% 78%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.9px at 44% 88%, rgba(255, 255, 255, 0.9), transparent 62%),
-    radial-gradient(circle 1.5px at 88% 82%, color-mix(in oklab, var(--rp-iris) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.3px at 30% 38%, color-mix(in oklab, var(--rp-foam) 75%, transparent), transparent 62%),
-    radial-gradient(circle 1.6px at 68% 40%, rgba(255, 255, 255, 0.85), transparent 62%),
-    radial-gradient(circle 1.3px at 6% 46%, color-mix(in oklab, var(--rp-iris) 80%, transparent), transparent 62%);
-  opacity: 0.92;
+    radial-gradient(circle 2px at 8% 13%, rgba(255, 255, 255, 0.95), transparent 60%),
+    radial-gradient(circle 1.6px at 27% 31%, color-mix(in oklab, var(--rp-iris) 92%, transparent), transparent 60%),
+    radial-gradient(circle 2.1px at 44% 8%, rgba(255, 255, 255, 0.9), transparent 60%),
+    radial-gradient(circle 1.7px at 61% 26%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 60%),
+    radial-gradient(circle 2px at 78% 11%, rgba(255, 255, 255, 0.9), transparent 60%),
+    radial-gradient(circle 1.6px at 92% 33%, color-mix(in oklab, var(--rp-iris) 88%, transparent), transparent 60%),
+    radial-gradient(circle 1.8px at 15% 52%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 60%),
+    radial-gradient(circle 2.1px at 36% 70%, rgba(255, 255, 255, 0.88), transparent 60%),
+    radial-gradient(circle 1.7px at 56% 50%, color-mix(in oklab, var(--rp-iris) 85%, transparent), transparent 60%),
+    radial-gradient(circle 2px at 73% 73%, rgba(255, 255, 255, 0.85), transparent 60%),
+    radial-gradient(circle 1.6px at 90% 60%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 60%),
+    radial-gradient(circle 2px at 9% 88%, rgba(255, 255, 255, 0.85), transparent 60%),
+    radial-gradient(circle 1.7px at 49% 92%, color-mix(in oklab, var(--rp-iris) 82%, transparent), transparent 60%),
+    radial-gradient(circle 1.9px at 80% 90%, rgba(255, 255, 255, 0.82), transparent 60%);
+  opacity: 0.95;
   filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-iris) 45%, transparent));
-  animation: pfield-drift 200s linear infinite, pfield-twinkle 7s ease-in-out infinite;
+  animation: pf-drift 150s linear infinite, pf-twinkle 6s ease-in-out infinite;
+}
+html.theme-void .theme-layer > .ocean-lights > .stars-far {
+  background-size: 360px 360px;
+  background-image:
+    radial-gradient(circle 1.1px at 17% 9%, color-mix(in oklab, var(--rp-iris) 70%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 33% 22%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle 1.1px at 47% 16%, color-mix(in oklab, var(--rp-foam) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 64% 7%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle 1.1px at 84% 23%, color-mix(in oklab, var(--rp-iris) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 10% 40%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle 1.1px at 28% 56%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 45% 66%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle 1.1px at 67% 44%, color-mix(in oklab, var(--rp-iris) 62%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 86% 52%, rgba(255, 255, 255, 0.5), transparent 60%),
+    radial-gradient(circle 1.1px at 20% 78%, color-mix(in oklab, var(--rp-foam) 58%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 58% 84%, rgba(255, 255, 255, 0.5), transparent 60%),
+    radial-gradient(circle 1.1px at 88% 80%, color-mix(in oklab, var(--rp-iris) 58%, transparent), transparent 60%);
+  opacity: 0.7;
+  animation: pf-drift 320s linear infinite reverse, pf-twinkle 9s ease-in-out infinite;
 }
 
-/* Forest — fireflies (near) + pollen (far) */
+/* ---- Forest: fireflies (near) + pollen (far) ---- */
 html.theme-forest .theme-layer > .ocean-lights > .stars-near {
-  background-size: 300px 300px;
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 2.8px at 18% 24%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 58%),
-    radial-gradient(circle 2.4px at 46% 16%, #a8e6c0, transparent 58%),
-    radial-gradient(circle 3px at 72% 30%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 58%),
-    radial-gradient(circle 2.4px at 30% 54%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 58%),
-    radial-gradient(circle 2.8px at 64% 62%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 58%),
-    radial-gradient(circle 2.4px at 86% 70%, #a8e6c0, transparent 58%),
-    radial-gradient(circle 2.6px at 12% 82%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 58%),
-    radial-gradient(circle 2.3px at 40% 88%, color-mix(in oklab, var(--rp-gold) 85%, transparent), transparent 58%);
+    radial-gradient(circle 2.6px at 9% 18%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 58%),
+    radial-gradient(circle 2.3px at 28% 38%, #a8e6c0, transparent 58%),
+    radial-gradient(circle 2.8px at 47% 12%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 58%),
+    radial-gradient(circle 2.2px at 63% 34%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 58%),
+    radial-gradient(circle 2.7px at 81% 18%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 58%),
+    radial-gradient(circle 2.3px at 18% 60%, #a8e6c0, transparent 58%),
+    radial-gradient(circle 2.6px at 40% 74%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 58%),
+    radial-gradient(circle 2.2px at 60% 56%, color-mix(in oklab, var(--rp-foam) 84%, transparent), transparent 58%),
+    radial-gradient(circle 2.7px at 84% 66%, color-mix(in oklab, var(--rp-gold) 88%, transparent), transparent 58%),
+    radial-gradient(circle 2.4px at 12% 88%, #a8e6c0, transparent 58%),
+    radial-gradient(circle 2.6px at 52% 90%, color-mix(in oklab, var(--rp-gold) 86%, transparent), transparent 58%);
   filter: drop-shadow(0 0 6px color-mix(in oklab, var(--rp-gold) 70%, transparent));
   opacity: 0.95;
-  animation: pfield-drift 140s ease-in-out infinite alternate, pfield-glow 4s ease-in-out infinite;
+  animation: pf-drift 130s ease-in-out infinite alternate, pf-glow 3.6s ease-in-out infinite;
 }
 html.theme-forest .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.4px at 22% 18%, color-mix(in oklab, var(--rp-gold) 80%, transparent), transparent 60%),
-    radial-gradient(circle 1.3px at 54% 32%, #a3d9b1, transparent 60%),
-    radial-gradient(circle 1.5px at 78% 22%, color-mix(in oklab, var(--rp-gold) 75%, transparent), transparent 60%),
-    radial-gradient(circle 1.3px at 34% 60%, #a3d9b1, transparent 60%),
-    radial-gradient(circle 1.4px at 66% 74%, color-mix(in oklab, var(--rp-gold) 78%, transparent), transparent 60%),
-    radial-gradient(circle 1.3px at 14% 88%, #a3d9b1, transparent 60%);
-  opacity: 0.6;
-  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-gold) 45%, transparent));
-  animation: pfield-rise 120s linear infinite, pfield-twinkle 9s ease-in-out infinite;
+    radial-gradient(circle 1.2px at 14% 12%, color-mix(in oklab, var(--rp-gold) 70%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 33% 26%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.2px at 52% 18%, color-mix(in oklab, var(--rp-gold) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 71% 10%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.2px at 88% 28%, color-mix(in oklab, var(--rp-gold) 68%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 22% 48%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.2px at 44% 60%, color-mix(in oklab, var(--rp-gold) 64%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 66% 70%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.2px at 84% 54%, color-mix(in oklab, var(--rp-gold) 66%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 16% 82%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1.2px at 58% 88%, color-mix(in oklab, var(--rp-gold) 62%, transparent), transparent 60%);
+  opacity: 0.55;
+  animation: pf-rise 150s linear infinite, pf-twinkle 7s ease-in-out infinite;
 }
 
-/* Ocean — rising bubbles (near) + plankton (far) */
+/* ---- Ocean: rising bubbles (near) + plankton (far) ---- */
 html.theme-ocean .theme-layer > .ocean-lights > .stars-near {
-  background-size: 300px 300px;
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 4px at 20% 80%, transparent 40%, color-mix(in oklab, var(--seafoam) 85%, transparent) 52%, transparent 66%),
-    radial-gradient(circle 3px at 48% 90%, transparent 40%, color-mix(in oklab, var(--rp-foam) 80%, transparent) 52%, transparent 66%),
-    radial-gradient(circle 5px at 72% 84%, transparent 42%, color-mix(in oklab, var(--seafoam) 80%, transparent) 52%, transparent 66%),
-    radial-gradient(circle 3px at 86% 76%, transparent 40%, color-mix(in oklab, var(--rp-foam) 78%, transparent) 52%, transparent 66%),
-    radial-gradient(circle 3.5px at 34% 70%, transparent 40%, color-mix(in oklab, var(--seafoam) 78%, transparent) 52%, transparent 66%),
-    radial-gradient(circle 2.6px at 58% 66%, transparent 40%, color-mix(in oklab, var(--rp-foam) 72%, transparent) 52%, transparent 66%);
-  opacity: 0.85;
-  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--seafoam) 50%, transparent));
-  animation: pfield-rise 26s linear infinite, pfield-twinkle 7s ease-in-out infinite;
+    radial-gradient(circle 4px at 12% 16%, transparent 42%, color-mix(in oklab, var(--seafoam) 85%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 3px at 34% 34%, transparent 42%, color-mix(in oklab, var(--rp-foam) 78%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 4.5px at 56% 12%, transparent 44%, color-mix(in oklab, var(--seafoam) 82%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 2.8px at 78% 30%, transparent 42%, color-mix(in oklab, var(--rp-foam) 76%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 3.4px at 22% 56%, transparent 42%, color-mix(in oklab, var(--seafoam) 80%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 4px at 48% 70%, transparent 44%, color-mix(in oklab, var(--rp-foam) 74%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 3px at 72% 60%, transparent 42%, color-mix(in oklab, var(--seafoam) 78%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 5px at 90% 80%, transparent 44%, color-mix(in oklab, var(--seafoam) 76%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 3px at 16% 86%, transparent 42%, color-mix(in oklab, var(--rp-foam) 72%, transparent) 52%, transparent 64%),
+    radial-gradient(circle 3.6px at 58% 92%, transparent 42%, color-mix(in oklab, var(--seafoam) 74%, transparent) 52%, transparent 64%);
+  opacity: 0.8;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--seafoam) 45%, transparent));
+  animation: pf-rise 30s linear infinite, pf-twinkle 6s ease-in-out infinite;
 }
 html.theme-ocean .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.5px at 18% 30%, color-mix(in oklab, var(--seafoam) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.3px at 52% 20%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 76% 40%, color-mix(in oklab, var(--seafoam) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.3px at 38% 64%, color-mix(in oklab, var(--rp-foam) 78%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 64% 78%, color-mix(in oklab, var(--seafoam) 82%, transparent), transparent 62%);
-  opacity: 0.6;
-  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-foam) 45%, transparent));
-  animation: pfield-rise 46s linear infinite, pfield-twinkle 8s ease-in-out infinite;
+    radial-gradient(circle 1.3px at 16% 12%, color-mix(in oklab, var(--seafoam) 78%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 38% 24%, color-mix(in oklab, var(--rp-foam) 70%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 60% 14%, color-mix(in oklab, var(--seafoam) 74%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 82% 30%, color-mix(in oklab, var(--rp-foam) 68%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 24% 48%, color-mix(in oklab, var(--seafoam) 72%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 50% 60%, color-mix(in oklab, var(--rp-foam) 66%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 74% 54%, color-mix(in oklab, var(--seafoam) 70%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 12% 76%, color-mix(in oklab, var(--rp-foam) 64%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 46% 84%, color-mix(in oklab, var(--seafoam) 72%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 86% 82%, color-mix(in oklab, var(--rp-foam) 64%, transparent), transparent 62%);
+  opacity: 0.55;
+  animation: pf-rise 56s linear infinite, pf-twinkle 8s ease-in-out infinite;
 }
 
-/* Aurora — snow / star dust */
-html.theme-aurora .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+/* ---- Aurora: snow / star dust (near + far) ---- */
+html.theme-aurora .theme-layer > .ocean-lights > .stars-near {
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.8px at 16% 14%, rgba(255, 255, 255, 0.95), transparent 62%),
-    radial-gradient(circle 1.4px at 40% 26%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 66% 16%, rgba(255, 255, 255, 0.9), transparent 62%),
-    radial-gradient(circle 1.4px at 84% 32%, color-mix(in oklab, var(--rp-iris) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 28% 50%, rgba(255, 255, 255, 0.9), transparent 62%),
-    radial-gradient(circle 1.5px at 56% 64%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 78% 60%, rgba(255, 255, 255, 0.85), transparent 62%),
-    radial-gradient(circle 1.4px at 14% 80%, color-mix(in oklab, var(--rp-iris) 75%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 46% 90%, rgba(255, 255, 255, 0.85), transparent 62%);
+    radial-gradient(circle 1.8px at 11% 14%, rgba(255, 255, 255, 0.95), transparent 62%),
+    radial-gradient(circle 1.5px at 31% 30%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 49% 12%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.5px at 68% 28%, color-mix(in oklab, var(--rp-iris) 78%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 86% 16%, rgba(255, 255, 255, 0.88), transparent 62%),
+    radial-gradient(circle 1.6px at 20% 54%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.5px at 44% 66%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 62%),
+    radial-gradient(circle 1.8px at 66% 52%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.5px at 88% 64%, color-mix(in oklab, var(--rp-iris) 72%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 14% 84%, rgba(255, 255, 255, 0.82), transparent 62%),
+    radial-gradient(circle 1.6px at 54% 88%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%);
   opacity: 0.9;
   filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-foam) 50%, transparent));
-  animation: pfield-fall 70s linear infinite, pfield-twinkle 6.5s ease-in-out infinite;
+  animation: pf-fall 60s linear infinite, pf-twinkle 6s ease-in-out infinite;
+}
+html.theme-aurora .theme-layer > .ocean-lights > .stars-far {
+  background-size: 360px 360px;
+  background-image:
+    radial-gradient(circle 1px at 22% 10%, rgba(255, 255, 255, 0.6), transparent 62%),
+    radial-gradient(circle 1px at 42% 22%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 64% 16%, rgba(255, 255, 255, 0.55), transparent 62%),
+    radial-gradient(circle 1px at 84% 34%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 14% 44%, rgba(255, 255, 255, 0.55), transparent 62%),
+    radial-gradient(circle 1px at 36% 58%, color-mix(in oklab, var(--rp-foam) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 58% 50%, rgba(255, 255, 255, 0.5), transparent 62%),
+    radial-gradient(circle 1px at 78% 66%, color-mix(in oklab, var(--rp-foam) 55%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 26% 78%, rgba(255, 255, 255, 0.5), transparent 62%),
+    radial-gradient(circle 1px at 62% 86%, color-mix(in oklab, var(--rp-iris) 52%, transparent), transparent 62%);
+  opacity: 0.65;
+  animation: pf-fall 120s linear infinite, pf-twinkle 9s ease-in-out infinite;
 }
 
-/* Ember — rising sparks */
-html.theme-ember .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+/* ---- Ember: rising sparks (near + far) ---- */
+html.theme-ember .theme-layer > .ocean-lights > .stars-near {
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.8px at 20% 86%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 44% 92%, color-mix(in oklab, var(--rp-love) 85%, transparent), transparent 62%),
-    radial-gradient(circle 2px at 66% 88%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 82% 80%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 32% 72%, color-mix(in oklab, var(--rp-gold) 88%, transparent), transparent 62%),
-    radial-gradient(circle 1.5px at 74% 66%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.6px at 14% 60%, color-mix(in oklab, var(--rp-gold) 82%, transparent), transparent 62%);
+    radial-gradient(circle 1.9px at 12% 16%, color-mix(in oklab, var(--rp-gold) 95%, transparent), transparent 62%),
+    radial-gradient(circle 1.6px at 33% 32%, color-mix(in oklab, var(--rp-love) 85%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 52% 14%, color-mix(in oklab, var(--rp-gold) 92%, transparent), transparent 62%),
+    radial-gradient(circle 1.6px at 72% 30%, color-mix(in oklab, var(--rp-rose) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 88% 18%, color-mix(in oklab, var(--rp-gold) 90%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 22% 54%, color-mix(in oklab, var(--rp-love) 82%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 46% 68%, color-mix(in oklab, var(--rp-gold) 88%, transparent), transparent 62%),
+    radial-gradient(circle 1.6px at 68% 56%, color-mix(in oklab, var(--rp-rose) 78%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 86% 70%, color-mix(in oklab, var(--rp-gold) 86%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 16% 84%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 56% 90%, color-mix(in oklab, var(--rp-gold) 84%, transparent), transparent 62%);
   opacity: 0.85;
   filter: drop-shadow(0 0 5px color-mix(in oklab, var(--rp-gold) 60%, transparent));
-  animation: pfield-rise 36s linear infinite, pfield-twinkle 4s ease-in-out infinite;
+  animation: pf-rise 34s linear infinite, pf-glow 3.4s ease-in-out infinite;
+}
+html.theme-ember .theme-layer > .ocean-lights > .stars-far {
+  background-size: 360px 360px;
+  background-image:
+    radial-gradient(circle 1.1px at 18% 10%, color-mix(in oklab, var(--rp-gold) 70%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 40% 24%, color-mix(in oklab, var(--rp-rose) 60%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 62% 16%, color-mix(in oklab, var(--rp-gold) 66%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 84% 30%, color-mix(in oklab, var(--rp-love) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 26% 48%, color-mix(in oklab, var(--rp-gold) 64%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 52% 60%, color-mix(in oklab, var(--rp-rose) 56%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 74% 54%, color-mix(in oklab, var(--rp-gold) 66%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 14% 76%, color-mix(in oklab, var(--rp-love) 56%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 48% 84%, color-mix(in oklab, var(--rp-gold) 62%, transparent), transparent 62%),
+    radial-gradient(circle 1px at 86% 82%, color-mix(in oklab, var(--rp-rose) 54%, transparent), transparent 62%);
+  opacity: 0.55;
+  animation: pf-rise 60s linear infinite, pf-twinkle 5s ease-in-out infinite;
 }
 
-/* Sakura — drifting blossom motes */
-html.theme-sakura .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+/* ---- Sakura: drifting blossom motes (near + far) ---- */
+html.theme-sakura .theme-layer > .ocean-lights > .stars-near {
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 2.2px at 18% 14%, color-mix(in oklab, var(--rp-rose) 92%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 44% 24%, color-mix(in oklab, var(--rp-love) 82%, transparent), transparent 62%),
-    radial-gradient(circle 2.4px at 70% 16%, color-mix(in oklab, var(--rp-rose) 88%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 30% 52%, color-mix(in oklab, var(--rp-iris) 72%, transparent), transparent 62%),
-    radial-gradient(circle 2.2px at 62% 60%, color-mix(in oklab, var(--rp-rose) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 84% 70%, color-mix(in oklab, var(--rp-love) 78%, transparent), transparent 62%),
-    radial-gradient(circle 2px at 10% 84%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 62%);
+    radial-gradient(circle 2.4px at 10% 14%, color-mix(in oklab, var(--rp-rose) 92%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 31% 30%, color-mix(in oklab, var(--rp-love) 82%, transparent), transparent 62%),
+    radial-gradient(circle 2.5px at 50% 12%, color-mix(in oklab, var(--rp-rose) 88%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 69% 28%, color-mix(in oklab, var(--rp-iris) 70%, transparent), transparent 62%),
+    radial-gradient(circle 2.4px at 87% 16%, color-mix(in oklab, var(--rp-rose) 86%, transparent), transparent 62%),
+    radial-gradient(circle 2.1px at 20% 54%, color-mix(in oklab, var(--rp-love) 80%, transparent), transparent 62%),
+    radial-gradient(circle 2.5px at 44% 68%, color-mix(in oklab, var(--rp-rose) 84%, transparent), transparent 62%),
+    radial-gradient(circle 2px at 66% 54%, color-mix(in oklab, var(--rp-iris) 66%, transparent), transparent 62%),
+    radial-gradient(circle 2.4px at 88% 66%, color-mix(in oklab, var(--rp-rose) 82%, transparent), transparent 62%),
+    radial-gradient(circle 2.1px at 14% 84%, color-mix(in oklab, var(--rp-love) 78%, transparent), transparent 62%),
+    radial-gradient(circle 2.4px at 56% 90%, color-mix(in oklab, var(--rp-rose) 80%, transparent), transparent 62%);
   opacity: 0.85;
   filter: drop-shadow(0 0 5px color-mix(in oklab, var(--rp-rose) 55%, transparent));
-  animation: pfield-fall 64s linear infinite, pfield-twinkle 7.5s ease-in-out infinite;
+  animation: pf-fall 54s linear infinite, pf-twinkle 7s ease-in-out infinite;
+}
+html.theme-sakura .theme-layer > .ocean-lights > .stars-far {
+  background-size: 360px 360px;
+  background-image:
+    radial-gradient(circle 1.3px at 20% 10%, color-mix(in oklab, var(--rp-rose) 65%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 42% 22%, color-mix(in oklab, var(--rp-love) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 64% 16%, color-mix(in oklab, var(--rp-rose) 62%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 84% 32%, color-mix(in oklab, var(--rp-iris) 52%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 14% 44%, color-mix(in oklab, var(--rp-rose) 60%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 38% 58%, color-mix(in oklab, var(--rp-love) 54%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 60% 50%, color-mix(in oklab, var(--rp-rose) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 80% 66%, color-mix(in oklab, var(--rp-love) 54%, transparent), transparent 62%),
+    radial-gradient(circle 1.3px at 26% 80%, color-mix(in oklab, var(--rp-rose) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 64% 86%, color-mix(in oklab, var(--rp-love) 52%, transparent), transparent 62%);
+  opacity: 0.6;
+  animation: pf-fall 100s linear infinite, pf-twinkle 9s ease-in-out infinite;
 }
 
-/* Glacier — drifting snow */
-html.theme-glacier .theme-layer > .ocean-lights > .stars-far {
-  background-size: 300px 300px;
+/* ---- Glacier: drifting snow (near + far) ---- */
+html.theme-glacier .theme-layer > .ocean-lights > .stars-near {
+  background-size: 360px 360px;
   background-image:
-    radial-gradient(circle 1.8px at 14% 16%, rgba(255, 255, 255, 0.95), transparent 62%),
-    radial-gradient(circle 1.4px at 40% 24%, color-mix(in oklab, var(--rp-foam) 90%, transparent), transparent 62%),
-    radial-gradient(circle 2px at 64% 14%, rgba(255, 255, 255, 0.9), transparent 62%),
-    radial-gradient(circle 1.4px at 84% 30%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 26% 50%, rgba(255, 255, 255, 0.88), transparent 62%),
-    radial-gradient(circle 1.5px at 54% 62%, color-mix(in oklab, var(--rp-foam) 85%, transparent), transparent 62%),
-    radial-gradient(circle 1.8px at 78% 58%, rgba(255, 255, 255, 0.85), transparent 62%),
-    radial-gradient(circle 1.4px at 16% 80%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
-    radial-gradient(circle 1.7px at 48% 90%, rgba(255, 255, 255, 0.85), transparent 62%);
+    radial-gradient(circle 1.9px at 11% 14%, rgba(255, 255, 255, 0.95), transparent 62%),
+    radial-gradient(circle 1.5px at 31% 30%, color-mix(in oklab, var(--rp-foam) 88%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 50% 12%, rgba(255, 255, 255, 0.9), transparent 62%),
+    radial-gradient(circle 1.5px at 69% 28%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 87% 16%, rgba(255, 255, 255, 0.88), transparent 62%),
+    radial-gradient(circle 1.6px at 20% 54%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.5px at 44% 68%, color-mix(in oklab, var(--rp-foam) 84%, transparent), transparent 62%),
+    radial-gradient(circle 1.9px at 66% 54%, rgba(255, 255, 255, 0.85), transparent 62%),
+    radial-gradient(circle 1.5px at 88% 66%, color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent 62%),
+    radial-gradient(circle 1.7px at 14% 84%, rgba(255, 255, 255, 0.82), transparent 62%),
+    radial-gradient(circle 1.6px at 56% 90%, color-mix(in oklab, var(--rp-foam) 82%, transparent), transparent 62%);
   opacity: 0.9;
   filter: drop-shadow(0 0 4px color-mix(in oklab, var(--rp-foam) 50%, transparent));
-  animation: pfield-fall 72s linear infinite, pfield-twinkle 6s ease-in-out infinite;
+  animation: pf-fall 58s linear infinite, pf-twinkle 5.5s ease-in-out infinite;
+}
+html.theme-glacier .theme-layer > .ocean-lights > .stars-far {
+  background-size: 360px 360px;
+  background-image:
+    radial-gradient(circle 1.1px at 22% 10%, rgba(255, 255, 255, 0.62), transparent 62%),
+    radial-gradient(circle 1px at 42% 22%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 64% 16%, rgba(255, 255, 255, 0.58), transparent 62%),
+    radial-gradient(circle 1px at 84% 34%, color-mix(in oklab, var(--rp-foam) 56%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 14% 44%, rgba(255, 255, 255, 0.55), transparent 62%),
+    radial-gradient(circle 1px at 36% 58%, color-mix(in oklab, var(--rp-foam) 58%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 58% 50%, rgba(255, 255, 255, 0.52), transparent 62%),
+    radial-gradient(circle 1px at 78% 66%, color-mix(in oklab, var(--rp-foam) 55%, transparent), transparent 62%),
+    radial-gradient(circle 1.1px at 26% 78%, rgba(255, 255, 255, 0.52), transparent 62%),
+    radial-gradient(circle 1px at 62% 86%, color-mix(in oklab, var(--rp-foam) 54%, transparent), transparent 62%);
+  opacity: 0.6;
+  animation: pf-fall 116s linear infinite, pf-twinkle 8.5s ease-in-out infinite;
 }
 
 /* ---- Reduced motion: freeze all per-theme FX layers --------------------- */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2487,9 +2487,41 @@ html.theme-cosmic .theme-layer > .ocean-lights > .stars-far {
   to   { transform: translate3d(4%, 3%, 0); }
 }
 
-/* Shooting star effect removed — it was animating opacity on the parent
-   .ocean-lights element, which hid the entire starfield for 97% of its cycle.
-   If a shooting star is desired later, it must live on its own dedicated layer. */
+/* Shooting star — lives on its OWN dedicated layer (the otherwise-unused
+   .forest-rays slot for cosmic) so it never affects the starfield's opacity.
+   A thin streak arcs across every ~14s; most of the cycle it is invisible.
+   Inherits the reduced-motion freeze via the generic .forest-rays::before rule. */
+html.theme-cosmic .theme-layer > .forest-rays {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 3;
+}
+
+html.theme-cosmic[data-motion="on"] .theme-layer > .forest-rays::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 14vw;
+  height: 1.5px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), color-mix(in oklab, var(--rp-foam) 80%, transparent), transparent);
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.7));
+  opacity: 0;
+  transform: translate3d(-16vw, 12vh, 0) rotate(22deg);
+  animation: cosmic-shooting-star 14s ease-in infinite;
+}
+
+@keyframes cosmic-shooting-star {
+  0%   { opacity: 0; transform: translate3d(-16vw, 10vh, 0) rotate(22deg); }
+  4%   { opacity: 0; transform: translate3d(-16vw, 10vh, 0) rotate(22deg); }
+  6%   { opacity: 1; }
+  16%  { opacity: 1; transform: translate3d(86vw, 46vh, 0) rotate(22deg); }
+  18%  { opacity: 0; transform: translate3d(92vw, 49vh, 0) rotate(22deg); }
+  100% { opacity: 0; transform: translate3d(92vw, 49vh, 0) rotate(22deg); }
+}
 
 /* ---- Ocean: slow rotating caustic light network ------------------------- */
 html.theme-ocean .theme-layer > .ocean-lights {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -425,6 +425,103 @@ html[data-motion="off"] .typing-cursor::after {
   background: transparent;
 }
 
+/* ==========================================================================
+   Standalone content pages (about / contact / privacy)
+   Bring the prose surfaces up to the same premium standard as the app.
+   ========================================================================== */
+.content-page {
+  min-height: 100vh;
+  background:
+    radial-gradient(ellipse 90% 55% at 50% -8%, color-mix(in oklab, var(--rp-iris) 15%, transparent) 0%, transparent 68%),
+    radial-gradient(ellipse 70% 50% at 82% 112%, color-mix(in oklab, var(--rp-foam) 9%, transparent) 0%, transparent 70%),
+    linear-gradient(180deg, var(--rp-base) 0%, color-mix(in oklab, var(--rp-overlay) 65%, var(--rp-base) 35%) 100%);
+}
+
+.content-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.content-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  color: var(--rp-subtle);
+  border: 1px solid color-mix(in oklab, var(--rp-iris) 14%, transparent);
+  background: color-mix(in oklab, var(--rp-overlay) 45%, transparent);
+  transition:
+    color 0.2s var(--ease-smooth),
+    background-color 0.2s var(--ease-smooth),
+    border-color 0.2s var(--ease-smooth),
+    transform 0.2s var(--ease-smooth);
+}
+
+.content-nav a:hover {
+  color: var(--rp-text);
+  background: color-mix(in oklab, var(--rp-iris) 16%, transparent);
+  border-color: color-mix(in oklab, var(--rp-iris) 32%, transparent);
+  transform: translateY(-1px);
+}
+
+/* Article card */
+.content-prose {
+  --prose-body: color-mix(in oklab, var(--rp-muted) 42%, var(--rp-text) 58%);
+}
+
+.content-prose h1 {
+  font-size: clamp(2.25rem, 1.6rem + 2.4vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  color: color-mix(in oklab, var(--rp-text) 82%, var(--rp-foam) 18%);
+}
+
+.content-prose .eyebrow {
+  color: var(--rp-iris);
+  text-shadow: 0 0 18px color-mix(in oklab, var(--rp-iris) 30%, transparent);
+}
+
+.content-prose h2 {
+  position: relative;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--rp-text);
+  padding-left: 0.85rem;
+}
+
+.content-prose h2::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.18em;
+  bottom: 0.18em;
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--rp-iris), var(--rp-foam));
+}
+
+.content-prose p {
+  color: var(--prose-body);
+  line-height: 1.75;
+}
+
+.content-prose a {
+  color: var(--rp-foam);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--rp-foam) 35%, transparent);
+  text-underline-offset: 0.18em;
+  transition: color 0.2s var(--ease-smooth), text-decoration-color 0.2s var(--ease-smooth);
+}
+
+.content-prose a:hover {
+  color: var(--rp-text);
+  text-decoration-color: color-mix(in oklab, var(--rp-foam) 70%, transparent);
+}
+
 /* High contrast mode */
 html.high-contrast .glass {
   background: color-mix(in oklab, var(--rp-surface) 92%, transparent);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2991,6 +2991,161 @@ html.theme-glacier .glass {
   }
 }
 
+/* ==========================================================================
+   Per-theme particle fields
+   Every theme gets its own crisp, characterful "stars-like" layer on the
+   .stars-near / .stars-far slots (previously cosmic-only) so each theme has a
+   signature presence, not just a blurred glow. All fields tile at 300px and
+   translate by exactly one tile, so they loop seamlessly while staying GPU
+   composited. They inherit cursor parallax from .ocean-lights and the
+   reduced-motion freeze below.
+   ========================================================================== */
+.theme-layer > .ocean-lights > .stars-near,
+.theme-layer > .ocean-lights > .stars-far {
+  position: absolute;
+  inset: -5%;
+  background-repeat: repeat;
+  pointer-events: none;
+}
+
+@keyframes pfield-twinkle { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
+@keyframes pfield-glow    { 0%, 100% { opacity: 0.42; } 50% { opacity: 0.85; } }
+@keyframes pfield-rise    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, -300px, 0); } }
+@keyframes pfield-fall    { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(0, 300px, 0); } }
+@keyframes pfield-drift   { from { transform: translate3d(0, 0, 0); } to { transform: translate3d(-300px, -300px, 0); } }
+
+/* Void — faint distant starfield (depth behind the aurora) */
+html.theme-void .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1px at 15% 12%, color-mix(in oklab, var(--rp-iris) 70%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 38% 28%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 62% 18%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle 0.8px at 82% 34%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 26% 52%, color-mix(in oklab, var(--rp-foam) 55%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 54% 66%, rgba(255, 255, 255, 0.5), transparent 60%),
+    radial-gradient(circle 1px at 74% 58%, color-mix(in oklab, var(--rp-iris) 60%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 12% 78%, color-mix(in oklab, var(--rp-foam) 50%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 44% 88%, rgba(255, 255, 255, 0.5), transparent 60%),
+    radial-gradient(circle 0.9px at 88% 82%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%);
+  opacity: 0.5;
+  animation: pfield-drift 220s linear infinite, pfield-twinkle 8s ease-in-out infinite;
+}
+
+/* Forest — fireflies (near) + pollen (far) */
+html.theme-forest .theme-layer > .ocean-lights > .stars-near {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1.6px at 18% 24%, color-mix(in oklab, var(--rp-gold) 85%, transparent), transparent 55%),
+    radial-gradient(circle 1.3px at 46% 16%, #8fd0a8, transparent 55%),
+    radial-gradient(circle 1.8px at 72% 30%, color-mix(in oklab, var(--rp-gold) 80%, transparent), transparent 55%),
+    radial-gradient(circle 1.4px at 30% 54%, color-mix(in oklab, var(--rp-foam) 70%, transparent), transparent 55%),
+    radial-gradient(circle 1.6px at 64% 62%, color-mix(in oklab, var(--rp-gold) 82%, transparent), transparent 55%),
+    radial-gradient(circle 1.3px at 86% 70%, #8fd0a8, transparent 55%),
+    radial-gradient(circle 1.5px at 12% 82%, color-mix(in oklab, var(--rp-gold) 78%, transparent), transparent 55%);
+  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--rp-gold) 50%, transparent));
+  opacity: 0.7;
+  animation: pfield-drift 140s ease-in-out infinite alternate, pfield-glow 4.5s ease-in-out infinite;
+}
+html.theme-forest .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 0.9px at 22% 18%, color-mix(in oklab, var(--rp-gold) 50%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 54% 32%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 1px at 78% 22%, color-mix(in oklab, var(--rp-gold) 45%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 34% 60%, #a3d9b1, transparent 60%),
+    radial-gradient(circle 0.9px at 66% 74%, color-mix(in oklab, var(--rp-gold) 48%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 14% 88%, #a3d9b1, transparent 60%);
+  opacity: 0.32;
+  animation: pfield-rise 120s linear infinite;
+}
+
+/* Ocean — rising bubbles (near) + plankton (far) */
+html.theme-ocean .theme-layer > .ocean-lights > .stars-near {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 2.5px at 20% 80%, transparent 36%, color-mix(in oklab, var(--seafoam) 55%, transparent) 48%, transparent 62%),
+    radial-gradient(circle 2px at 48% 90%, transparent 36%, color-mix(in oklab, var(--rp-foam) 50%, transparent) 48%, transparent 62%),
+    radial-gradient(circle 3px at 72% 84%, transparent 36%, color-mix(in oklab, var(--seafoam) 50%, transparent) 48%, transparent 62%),
+    radial-gradient(circle 2px at 86% 76%, transparent 36%, color-mix(in oklab, var(--rp-foam) 48%, transparent) 48%, transparent 62%),
+    radial-gradient(circle 2.2px at 34% 70%, transparent 36%, color-mix(in oklab, var(--seafoam) 48%, transparent) 48%, transparent 62%);
+  opacity: 0.55;
+  animation: pfield-rise 26s linear infinite, pfield-twinkle 7s ease-in-out infinite;
+}
+html.theme-ocean .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1px at 18% 30%, color-mix(in oklab, var(--seafoam) 55%, transparent), transparent 60%),
+    radial-gradient(circle 0.8px at 52% 20%, color-mix(in oklab, var(--rp-foam) 50%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 76% 40%, color-mix(in oklab, var(--seafoam) 50%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 38% 64%, color-mix(in oklab, var(--rp-foam) 48%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 64% 78%, color-mix(in oklab, var(--seafoam) 52%, transparent), transparent 60%);
+  opacity: 0.3;
+  animation: pfield-rise 46s linear infinite;
+}
+
+/* Aurora — fine snow / star dust */
+html.theme-aurora .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1px at 16% 14%, rgba(255, 255, 255, 0.7), transparent 60%),
+    radial-gradient(circle 0.8px at 40% 26%, color-mix(in oklab, var(--rp-foam) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 66% 16%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle 0.8px at 84% 32%, color-mix(in oklab, var(--rp-iris) 55%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 28% 50%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle 0.9px at 56% 64%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 78% 60%, rgba(255, 255, 255, 0.55), transparent 60%),
+    radial-gradient(circle 0.8px at 14% 80%, color-mix(in oklab, var(--rp-iris) 50%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 46% 90%, rgba(255, 255, 255, 0.55), transparent 60%);
+  opacity: 0.5;
+  animation: pfield-fall 80s linear infinite, pfield-twinkle 6.5s ease-in-out infinite;
+}
+
+/* Ember — distant rising sparks */
+html.theme-ember .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1.1px at 20% 86%, color-mix(in oklab, var(--rp-gold) 75%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 44% 92%, color-mix(in oklab, var(--rp-love) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1.2px at 66% 88%, color-mix(in oklab, var(--rp-gold) 70%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 82% 80%, color-mix(in oklab, var(--rp-rose) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 32% 72%, color-mix(in oklab, var(--rp-gold) 68%, transparent), transparent 60%),
+    radial-gradient(circle 0.9px at 74% 66%, color-mix(in oklab, var(--rp-love) 58%, transparent), transparent 60%);
+  opacity: 0.42;
+  animation: pfield-rise 38s linear infinite, pfield-twinkle 4s ease-in-out infinite;
+}
+
+/* Sakura — distant drifting blossom motes */
+html.theme-sakura .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1.2px at 18% 14%, color-mix(in oklab, var(--rp-rose) 70%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 44% 24%, color-mix(in oklab, var(--rp-love) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1.3px at 70% 16%, color-mix(in oklab, var(--rp-rose) 65%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 30% 52%, color-mix(in oklab, var(--rp-iris) 50%, transparent), transparent 60%),
+    radial-gradient(circle 1.2px at 62% 60%, color-mix(in oklab, var(--rp-rose) 62%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 84% 70%, color-mix(in oklab, var(--rp-love) 55%, transparent), transparent 60%);
+  opacity: 0.4;
+  animation: pfield-fall 70s linear infinite, pfield-twinkle 7.5s ease-in-out infinite;
+}
+
+/* Glacier — fine drifting snow */
+html.theme-glacier .theme-layer > .ocean-lights > .stars-far {
+  background-size: 300px 300px;
+  background-image:
+    radial-gradient(circle 1px at 14% 16%, rgba(255, 255, 255, 0.75), transparent 60%),
+    radial-gradient(circle 0.8px at 40% 24%, color-mix(in oklab, var(--rp-foam) 70%, transparent), transparent 60%),
+    radial-gradient(circle 1.1px at 64% 14%, rgba(255, 255, 255, 0.7), transparent 60%),
+    radial-gradient(circle 0.8px at 84% 30%, color-mix(in oklab, var(--rp-foam) 60%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 26% 50%, rgba(255, 255, 255, 0.65), transparent 60%),
+    radial-gradient(circle 0.9px at 54% 62%, color-mix(in oklab, var(--rp-foam) 62%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 78% 58%, rgba(255, 255, 255, 0.6), transparent 60%),
+    radial-gradient(circle 0.8px at 16% 80%, color-mix(in oklab, var(--rp-foam) 58%, transparent), transparent 60%),
+    radial-gradient(circle 1px at 48% 90%, rgba(255, 255, 255, 0.6), transparent 60%);
+  opacity: 0.55;
+  animation: pfield-fall 75s linear infinite, pfield-twinkle 6s ease-in-out infinite;
+}
+
 /* ---- Reduced motion: freeze all per-theme FX layers --------------------- */
 html[data-motion="off"] .theme-layer > .ocean-lights,
 html[data-motion="off"] .theme-layer > .ocean-lights::before,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1436,7 +1436,7 @@ html.theme-forest .forest-rays::before {
     radial-gradient(120% 90% at 50% 2%, color-mix(in oklab, var(--forest-ray-core) 58%, transparent) 0%, transparent 78%),
     radial-gradient(145% 95% at 48% 28%, color-mix(in oklab, var(--forest-ray-soft) 52%, transparent) 0%, transparent 85%),
     radial-gradient(100% 70% at 50% 8%, color-mix(in oklab, var(--jade) 24%, transparent) 0%, transparent 88%);
-  opacity: 0.22;
+  opacity: 0.32;
   animation:
     forest-ray-veil calc(150s * 1.04) cubic-bezier(0.28, 0.62, 0.3, 0.94) infinite;
 }
@@ -1447,7 +1447,7 @@ html.theme-forest .forest-rays::after {
     linear-gradient(102deg, transparent 0%, color-mix(in oklab, var(--forest-ray-falloff) 68%, transparent) 26%, transparent 58%),
     linear-gradient(168deg, transparent 0%, color-mix(in oklab, var(--forest-leaf-highlight) 58%, transparent) 38%, transparent 85%),
     radial-gradient(ellipse 80% 60% at 50% 15%, color-mix(in oklab, var(--emerald) 18%, transparent) 0%, transparent 100%);
-  opacity: 0.18;
+  opacity: 0.26;
   mix-blend-mode: screen;
   animation:
     forest-ray-sweep calc(146s * 0.96) cubic-bezier(0.26, 0.68, 0.3, 0.96) infinite;
@@ -1858,7 +1858,7 @@ html.theme-void .theme-layer::before {
   background-position: center;
   background-repeat: no-repeat;
   mix-blend-mode: screen;
-  opacity: .58;
+  opacity: .7;
   animation: void-aurora-drift calc(88s * 1.05) cubic-bezier(0.32, 0.68, 0.3, 0.96) infinite;
 }
 
@@ -2200,15 +2200,18 @@ html.theme-void[data-motion="on"] .theme-layer > .ocean-lights::after {
 }
 
 @keyframes void-dust-fade {
-  0%   { opacity: 0.28; }
-  100% { opacity: 0.42; }
+  0%   { opacity: 0.42; }
+  100% { opacity: 0.62; }
 }
 
-/* Reduced motion: freeze all flourishes */
+/* Reduced motion: freeze all flourishes (including the cosmic starfield, which
+   was previously left drifting/twinkling under reduced motion) */
 html[data-motion="off"] .theme-layer > .forest-rays::before,
 html[data-motion="off"] .theme-layer > .forest-rays::after,
 html[data-motion="off"] .theme-layer > .ocean-lights::before,
-html[data-motion="off"] .theme-layer > .ocean-lights::after {
+html[data-motion="off"] .theme-layer > .ocean-lights::after,
+html[data-motion="off"] .theme-layer > .ocean-lights > .stars-near,
+html[data-motion="off"] .theme-layer > .ocean-lights > .stars-far {
   animation: none !important;
   transform: none !important;
 }
@@ -2217,7 +2220,9 @@ html[data-motion="off"] .theme-layer > .ocean-lights::after {
   .theme-layer > .forest-rays::before,
   .theme-layer > .forest-rays::after,
   .theme-layer > .ocean-lights::before,
-  .theme-layer > .ocean-lights::after {
+  .theme-layer > .ocean-lights::after,
+  .theme-layer > .ocean-lights > .stars-near,
+  .theme-layer > .ocean-lights > .stars-far {
     animation: none !important;
     transform: none !important;
   }
@@ -2321,7 +2326,9 @@ html.theme-cosmic .theme-layer > .ocean-lights > .stars-near {
     radial-gradient(circle 2px at 77% 67%, rgba(255, 160, 100, 1), transparent),
     radial-gradient(circle 1.5px at 5% 58%, rgba(200, 180, 255, 1), transparent);
   opacity: 1;
-  animation: cosmic-star-drift 240s linear infinite;
+  animation:
+    cosmic-star-drift 240s linear infinite,
+    cosmic-star-twinkle 7s ease-in-out infinite;
 }
 
 /* Far starfield: smaller stars, independent drift */
@@ -2346,7 +2353,9 @@ html.theme-cosmic .theme-layer > .ocean-lights > .stars-far {
     radial-gradient(circle 1px at 82% 96%, rgba(255, 200, 100, 0.75), transparent);
   background-size: 520px 520px;
   opacity: 0.8;
-  animation: cosmic-star-drift-slow 420s linear infinite reverse;
+  animation:
+    cosmic-star-drift-slow 420s linear infinite reverse,
+    cosmic-star-twinkle 11s ease-in-out infinite 1.5s;
 }
 
 @keyframes cosmic-star-twinkle {
@@ -2380,20 +2389,20 @@ html.theme-ocean .theme-layer > .ocean-lights::before {
     conic-gradient(
       from 0deg at 50% 50%,
       transparent 0deg,
-      color-mix(in oklab, var(--seafoam) 22%, transparent) 12deg,
+      color-mix(in oklab, var(--seafoam) 30%, transparent) 12deg,
       transparent 40deg,
-      color-mix(in oklab, var(--cyan) 18%, transparent) 78deg,
+      color-mix(in oklab, var(--cyan) 25%, transparent) 78deg,
       transparent 110deg,
-      color-mix(in oklab, var(--seafoam) 24%, transparent) 168deg,
+      color-mix(in oklab, var(--seafoam) 32%, transparent) 168deg,
       transparent 200deg,
-      color-mix(in oklab, var(--aqua) 20%, transparent) 242deg,
+      color-mix(in oklab, var(--aqua) 27%, transparent) 242deg,
       transparent 282deg,
-      color-mix(in oklab, var(--seafoam) 22%, transparent) 320deg,
+      color-mix(in oklab, var(--seafoam) 30%, transparent) 320deg,
       transparent 360deg
     );
-  filter: blur(42px);
+  filter: blur(38px);
   mix-blend-mode: screen;
-  animation: ocean-caustic-rotate 140s linear infinite;
+  animation: ocean-caustic-rotate 110s linear infinite;
 }
 
 html.theme-ocean[data-motion="on"] .theme-layer > .ocean-lights::after {
@@ -2694,22 +2703,23 @@ html.theme-ocean .glass {
 /* Theme-swap transitions: only active when data-transition-theme is set by ThemeToggle.
    Uses the vt-theme-fade-* keyframes defined below for a smooth cross-fade. */
 html[data-transition-theme]::view-transition-old(root) {
-  animation: 400ms cubic-bezier(0.22, 1, 0.36, 1) both vt-theme-fade-out;
+  animation: 280ms cubic-bezier(0.4, 0, 1, 1) both vt-theme-fade-out;
 }
 
 html[data-transition-theme]::view-transition-new(root) {
-  animation: 400ms cubic-bezier(0.22, 1, 0.36, 1) both vt-theme-fade-in;
+  animation: 460ms cubic-bezier(0.22, 1, 0.36, 1) both vt-theme-fade-in;
 }
 
-/* Pure cross-fade specifically for theme swaps \u2014 no scale or blur,
-   just brightness so the color palette morphs cinematically */
+/* Cinematic theme swap: the outgoing palette drains (desaturates + dims) while
+   the incoming one snaps into focus from a touch over-saturated. The staggered
+   timing makes the new scene feel like it "fills in" rather than a flat blend. */
 @keyframes vt-theme-fade-out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
+  from { opacity: 1; filter: saturate(1) brightness(1); }
+  to   { opacity: 0; filter: saturate(0.65) brightness(0.9); }
 }
 @keyframes vt-theme-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from { opacity: 0; filter: saturate(1.14) brightness(1.05); }
+  to   { opacity: 1; filter: saturate(1) brightness(1); }
 }
 
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -522,6 +522,35 @@ html[data-motion="off"] .typing-cursor::after {
   text-decoration-color: color-mix(in oklab, var(--rp-foam) 70%, transparent);
 }
 
+/* ==========================================================================
+   Overlay / modal entrance choreography
+   Backdrop fades in while the card rises + scales into focus. Applied to the
+   PauseMenu, HelpSheet, and About overlays for a unified, premium entrance.
+   ========================================================================== */
+.overlay-backdrop {
+  animation: overlay-backdrop-in 0.26s var(--ease-smooth) both;
+}
+
+.overlay-card {
+  animation: overlay-card-in 0.34s var(--ease-smooth) both;
+  animation-delay: 0.04s;
+}
+
+@keyframes overlay-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes overlay-card-in {
+  from { opacity: 0; transform: translateY(10px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+html[data-motion="off"] .overlay-backdrop,
+html[data-motion="off"] .overlay-card {
+  animation: none !important;
+}
+
 /* High contrast mode */
 html.high-contrast .glass {
   background: color-mix(in oklab, var(--rp-surface) 92%, transparent);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2385,6 +2385,16 @@ html.high-contrast.theme-void .theme-layer::after {
   pointer-events: none;
   z-index: 2;
   overflow: hidden;
+  /* Interactive depth: the FX layer drifts gently toward the cursor for every
+     theme (SpotlightLayer exposes --cursor-nx/ny on :root, 0..1 normalized).
+     Cosmic overrides this with a stronger parallax below; reduced-motion forces
+     transform:none via the freeze rules. */
+  transform: translate3d(
+    calc((var(--cursor-nx, 0.5) - 0.5) * -14px),
+    calc((var(--cursor-ny, 0.5) - 0.5) * -14px),
+    0
+  );
+  transition: transform 0.9s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* On small viewports (mostly mobile GPUs) drop the most expensive layers:
@@ -2606,7 +2616,7 @@ html.theme-void .theme-layer > .ocean-lights::before {
   filter: blur(56px);
   mix-blend-mode: screen;
   transform-origin: 50% 50%;
-  animation: void-aurora-sweep 180s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation: void-aurora-sweep 120s cubic-bezier(0.45, 0, 0.55, 1) infinite;
 }
 
 html.theme-void[data-motion="on"] .theme-layer > .ocean-lights::after {
@@ -2626,7 +2636,7 @@ html.theme-void[data-motion="on"] .theme-layer > .ocean-lights::after {
   filter: blur(40px);
   mix-blend-mode: screen;
   opacity: 0.7;
-  animation: void-aurora-sweep-2 220s cubic-bezier(0.45, 0, 0.55, 1) infinite reverse;
+  animation: void-aurora-sweep-2 150s cubic-bezier(0.45, 0, 0.55, 1) infinite reverse;
 }
 
 @keyframes void-aurora-sweep {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -166,7 +166,7 @@ export function applySettingsSideEffects(patch: Partial<Settings>, next: Setting
 
 // Type definitions
 export interface Settings {
-  theme: 'Void' | 'Forest' | 'Ocean' | 'Cosmic';
+  theme: 'Void' | 'Forest' | 'Ocean' | 'Cosmic' | 'Ember' | 'Sakura' | 'Aurora' | 'Glacier';
   reducedMotion: boolean;
   showStats: boolean;
   highContrast: boolean;
@@ -290,7 +290,7 @@ export function getSettings(): Settings {
     normalized.theme = 'Void';
   }
 
-  const allowedThemes: Settings['theme'][] = ['Void', 'Forest', 'Ocean', 'Cosmic'];
+  const allowedThemes: Settings['theme'][] = ['Void', 'Forest', 'Ocean', 'Cosmic', 'Ember', 'Sakura', 'Aurora', 'Glacier'];
   if (!allowedThemes.includes(normalized.theme)) {
     normalized.theme = 'Void';
   }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,9 @@ module.exports = {
         pine: "var(--rp-pine)",
         foam: "var(--rp-foam)",
         iris: "var(--rp-iris)",
+        // Theme-reactive accents — shift with the active theme so UI never clashes
+        tint: "var(--theme-accent)",
+        tint2: "var(--theme-accent-2)",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
Elevates the app from "70% there" to a polished, cohesive whole — without changing the Rosé Pine / zen identity. 17 commits, grouped below.

## Typing surfaces
- **Quote mode**: removed the noisy per-character underlines for a clean color-driven state system (pending / correct / current caret / error); words never wrap mid-word; dropped the redundant stats card (the bottom HUD is now the single live surface) and added one slim progress line; redesigned the completion screen (hero WPM/accuracy, breakdown cards, clear button hierarchy).
- **Zen mode**: floating tokens now spring in with real entrance choreography, drift organically (de-synced dual-sine), and glow; the input is a living instrument (focus-breathing + commit ripple); fixed an off-screen input regression; removed leftover debug logs.

## Themes (now 8)
- Added **Ember, Sakura, Aurora, Glacier** alongside Void / Forest / Ocean / Cosmic — each with a distinct gradient and signature.
- **Every theme is alive**: a two-layer (near + far) particle field with parallax depth — Void starfield, Forest fireflies + pollen, Ocean bubbles + plankton, Aurora/Glacier snow, Ember sparks, Sakura blossoms, plus Cosmic's existing field + a new shooting star.
- Cursor parallax on every theme; livelier Void aurora; cinematic color-graded theme switch.
- Fields tile at 360px and translate by one tile so they loop seamlessly and stay GPU-composited; all respect reduced-motion.

## Theme-reactive UI ("nothing out of place")
- Per-theme `--theme-accent` / `--theme-accent-2` (Tailwind `tint`/`tint2`) drive the caret, typed text, progress, focus rings, glass/card borders, the live stats, the completion screen, header pills, pause menu, content pages, and the zen input — so the whole UI recolors to match the active theme. Errors stay red (semantic).

## Chrome, overlays & content
- Unified overlay entrance choreography (PauseMenu / HelpSheet / About / Drafts); safe-area-aware HUD + footer.
- About / Contact / Privacy brought up to the app's standard (glass article card, type scale, themed nav, motion).

## Fixes
- `fix(hud)`: valid `calc()` for the safe-area HUD offset.
- `fix(zen)`: canvas ambience (leaves/bubbles) no longer lags one theme behind — the theme was read from the class while it was still mid-View-Transition; now read from the event payload.

## Verification
- `bun run build`, `astro check`, and ESLint all pass.
- Two adversarial multi-agent reviews over the diff returned no confirmed regressions (one dead-code finding and one `calc()` bug were fixed).
- Verified across themes in-browser (warm Ember, cool Glacier, soft Sakura) for the reactive UI and particle distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)