### PR TITLE
chore: gitignore .claude/ local tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ squirrel-audits/
 .idea/
 .vscode/
 *.swp
-# misc
+
+# Claude Code local tooling / session artifacts (preview launch config, locks)
+.claude/


### PR DESCRIPTION
The `.claude/` directory holds Claude Code local tooling — the preview server `launch.json` and scheduled-task lock files. These are session/dev artifacts, not application code, and were showing up as untracked.

Adds `.claude/` to `.gitignore` so they stay out of the repo and the working tree stays clean. Nothing under `.claude/` was tracked, so this only affects future status — no files removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)